### PR TITLE
Add shared nav component and wire Kanban into global navigation

### DIFF
--- a/components/nav.html
+++ b/components/nav.html
@@ -1,0 +1,6 @@
+<nav class="main-nav">
+  <a href="index.html" data-page="dashboard">Dashboard</a>
+  <a href="intelligence.html" data-page="intelligence">Intelligence</a>
+  <a href="pptx.html" data-page="pptx">PPTX</a>
+  <a href="kanban.html" data-page="kanban">Kanban</a>
+</nav>

--- a/index.html
+++ b/index.html
@@ -7,22 +7,22 @@
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=IBM+Plex+Sans:wght@300;400;600;700&family=IBM+Plex+Sans+Condensed:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
-<body>
+<body data-page="dashboard">
+<div id="nav-container"></div>
+
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  });
+</script>
+
 <div class="layout">
-  <div class="topnav">
-    <div class="topnav-label">AI Project Dashboard</div>
-    <div class="topnav-links">
-      <a class="topnav-link active" href="/status-site/index.html">Dashboard</a>
-      <a class="topnav-link" href="/status-site/decisions.html">Decisions</a>
-      <a class="topnav-link" href="/status-site/scenarios.html">Scenarios</a>
-      <a class="topnav-link" href="/status-site/intelligence.html">Intelligence</a>
-      <a class="topnav-link" href="/status-site/artifacts.html">Artifacts</a>
-      <a class="topnav-link" href="/status-site/path-architecture.html">Architecture</a>
-      <a class="topnav-link" href="/status-site/control-plane.html">Control Plane</a>
-      <a class="topnav-link" href="/status-site/pptx-builder.html">PPTX</a>
-      <a class="topnav-link" href="/status-site/settings.html">Settings</a>
-    </div>
-  </div>
+  
 
   <div class="dashboard">
     <div class="left-rail">

--- a/intelligence.html
+++ b/intelligence.html
@@ -8,21 +8,22 @@
   <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="css/editor.css">
 </head>
-<body>
+<body data-page="intelligence">
+<div id="nav-container"></div>
 
-<div class="topnav">
-  <div class="topnav-label">AI Project Dashboard</div>
-  <div class="topnav-links">
-    <a class="topnav-link" href="/status-site/index.html">Dashboard</a>
-    <a class="topnav-link" href="/status-site/decisions.html">Decisions</a>
-    <a class="topnav-link" href="/status-site/scenarios.html">Scenarios</a>
-    <a class="topnav-link active" href="/status-site/intelligence.html">Intelligence</a>
-    <a class="topnav-link" href="/status-site/artifacts.html">Artifacts</a>
-    <a class="topnav-link" href="/status-site/path-architecture.html">Architecture</a>
-    <a class="topnav-link" href="/status-site/control-plane.html">Control Plane</a>
-    <a class="topnav-link" href="/status-site/pptx-builder.html">PPTX</a>
-  </div>
-</div>
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  });
+</script>
+
+
+
 
 <div class="breadcrumb">Dashboard &gt; Intelligence &gt; Platform & Architecture</div>
 

--- a/kanban.html
+++ b/kanban.html
@@ -8,23 +8,22 @@
   <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="kanban.css">
 </head>
-<body>
+<body data-page="kanban">
+<div id="nav-container"></div>
+
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  });
+</script>
+
 <div class="layout">
-  <div class="topnav">
-    <div class="topnav-label">AI Project Dashboard</div>
-    <div class="topnav-links">
-      <a class="topnav-link" href="/status-site/index.html">Dashboard</a>
-      <a class="topnav-link" href="/status-site/decisions.html">Decisions</a>
-      <a class="topnav-link" href="/status-site/scenarios.html">Scenarios</a>
-      <a class="topnav-link" href="/status-site/intelligence.html">Intelligence</a>
-      <a class="topnav-link" href="/status-site/artifacts.html">Artifacts</a>
-      <a class="topnav-link" href="/status-site/path-architecture.html">Architecture</a>
-      <a class="topnav-link" href="/status-site/control-plane.html">Control Plane</a>
-      <a class="topnav-link" href="/status-site/pptx-builder.html">PPTX</a>
-      <a class="topnav-link active" href="/status-site/kanban.html">Kanban</a>
-      <a class="topnav-link" href="/status-site/settings.html">Settings</a>
-    </div>
-  </div>
+  
 
   <div class="breadcrumb">Dashboard &gt; Execution Board</div>
 

--- a/pptx-builder.html
+++ b/pptx-builder.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>PPTX Builder — PATH Status Site</title>
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=IBM+Plex+Sans:wght@300;400;600;700&family=IBM+Plex+Sans+Condensed:wght@700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="styles.css">
 <style>
 :root{--teal:#00C8C8;--red:#E8192E;--gold:#F9D030;--blue:#5FA8E8;--bg:#07090F;--bg2:#0D1117;--bg3:#131920;--surface:#1A2230;--border:rgba(255,255,255,.10);--text:#F0F4FA;--text-dim:#B0BFCF;--text-faint:#6A7D90;--mono:'IBM Plex Mono', monospace;--sans:'IBM Plex Sans', sans-serif;--cond:'IBM Plex Sans Condensed', sans-serif}
 *{box-sizing:border-box;margin:0;padding:0}
@@ -31,21 +32,21 @@ textarea{width:100%;white-space:pre-wrap;word-break:break-word;background:#0a101
 @media(max-width:980px){body{width:auto;padding:20px}.grid{grid-template-columns:1fr}}
 </style>
 </head>
-<body>
-<div class="topnav">
-  <div class="topnav-label">AI Project Dashboard</div>
-  <div class="topnav-links">
-    <a href="/status-site/index.html">Dashboard</a>
-    <a href="/status-site/decisions.html">Decisions</a>
-    <a href="/status-site/scenarios.html">Scenarios</a>
-    <a href="/status-site/intelligence.html">Intelligence</a>
-    <a href="/status-site/artifacts.html">Artifacts</a>
-    <a href="/status-site/path-architecture.html">Architecture</a>
-    <a href="/status-site/control-plane.html">Control Plane</a>
-    <a href="/status-site/pptx-builder.html" class="active">PPTX</a>
-    <a href="/status-site/settings.html">Settings</a>
-  </div>
-</div>
+<body data-page="pptx">
+<div id="nav-container"></div>
+
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  });
+</script>
+
+
 
 <div class="breadcrumb">Overview &gt; PPTX Builder</div>
 

--- a/pptx.html
+++ b/pptx.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0; url=pptx-builder.html">
+  <title>PPTX</title>
+</head>
+<body data-page="pptx">
+  <p>Redirecting to <a href="pptx-builder.html">PPTX Builder</a>...</p>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -914,3 +914,27 @@ body {
     font-size: 11px;
   }
 }
+
+.main-nav {
+  display: flex;
+  gap: 20px;
+  padding: 12px 20px;
+  background: #1f2a30;
+  border-bottom: 1px solid #2f6f73;
+}
+
+.main-nav a {
+  color: #d0d7da;
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.main-nav a:hover {
+  color: #ffffff;
+}
+
+.main-nav a.active {
+  color: #a6ce39;
+  border-bottom: 2px solid #a6ce39;
+}


### PR DESCRIPTION
### Motivation
- Standardize the site header into a single reusable component to avoid duplicated markup across pages.
- Enable a simple, client-side shared navigation that highlights the active page via a `data-page` attribute.
- Prepare the site for embedding modular pages (e.g., Kanban) into a shared UI shell.

### Description
- Added `components/nav.html` containing the shared `<nav class="main-nav">` with links and `data-page` attributes for Dashboard, Intelligence, PPTX, and Kanban.
- Updated `index.html`, `intelligence.html`, `kanban.html`, and `pptx-builder.html` to add `data-page` on the `<body>` and inject `<div id="nav-container"></div>` plus a small `fetch('components/nav.html')` script that mounts the nav and applies the `.active` class based on `body.dataset.page`.
- Added `pptx.html` as a lightweight redirect to `pptx-builder.html` so the shared `pptx.html` link resolves.
- Appended `.main-nav` styling (link, hover, active states) to `styles.css` to style the shared navigation.

### Testing
- Repository file/diff inspections were performed to verify the new `components/nav.html` and the modified pages include the injected nav and `data-page` attributes.
- Local verification confirmed the `styles.css` additions are present and the redirect shim `pptx.html` was created.
- Changes were recorded locally in the working branch; attempt to push to a remote could not be completed because no remote is configured in this environment.
- No automated unit or UI tests exist for these pages and none were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8af35e5f48322b023ce0376a2411d)