### PR TITLE
Introduce reusable navigation component and centralize header styling

### DIFF
--- a/artifacts.html
+++ b/artifacts.html
@@ -23,22 +23,24 @@ input::placeholder{color:var(--text-faint)}
 .card:hover{border-color:var(--teal)}
 a{color:var(--teal);text-decoration:none}
 </style>
+<link rel="stylesheet" href="styles.css">
 </head>
-<body>
-<div class="topnav">
-  <div class="topnav-label">AI Project Dashboard</div>
-  <div class="topnav-links">
-    <a class="topnav-link" href="/status-site/index.html">Dashboard</a>
-    <a class="topnav-link" href="/status-site/decisions.html">Decisions</a>
-    <a class="topnav-link" href="/status-site/scenarios.html">Scenarios</a>
-    <a class="topnav-link" href="/status-site/intelligence.html">Intelligence</a>
-    <a class="topnav-link active" href="/status-site/artifacts.html">Artifacts</a>
-    <a class="topnav-link" href="/status-site/path-architecture.html">Architecture</a>
-    <a class="topnav-link" href="/status-site/control-plane.html">Control Plane</a>
-    <a class="topnav-link" href="/status-site/pptx-builder.html">PPTX</a>
-    <a class="topnav-link" href="/status-site/settings.html">Settings</a>
-  </div>
-</div>
+<body data-page="artifacts">
+<div id="nav-container"></div>
+
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+
+
 <div class="breadcrumb">Overview &gt; EA Artifacts</div>
 <h1>EA Artifacts</h1>
 <input id="search" placeholder="Search artifacts..." onkeyup="filter()">

--- a/assessment.html
+++ b/assessment.html
@@ -7,15 +7,23 @@
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=IBM+Plex+Sans:wght@300;400;600;700&family=IBM+Plex+Sans+Condensed:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
-<body>
+<body data-page="assessment">
+<div id="nav-container"></div>
+
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+
 <div class="layout">
-  <div class="topnav">
-    <div class="topnav-label">AI Project Dashboard</div>
-    <div class="topnav-links">
-      <a class="topnav-link" href="/status-site/index.html">Dashboard</a>
-      <a class="topnav-link active" href="/status-site/assessments.html">Assessments</a>
-    </div>
-  </div>
+  
 
   <div class="breadcrumb">Assessments &gt; Detail</div>
 

--- a/assessments-compare.html
+++ b/assessments-compare.html
@@ -7,9 +7,23 @@
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=IBM+Plex+Sans:wght@300;400;600;700&family=IBM+Plex+Sans+Condensed:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
-<body>
+<body data-page="assessments-compare">
+<div id="nav-container"></div>
+
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+
 <div class="layout">
-  <div class="topnav"><div class="topnav-label">AI Project Dashboard</div></div>
+  
   <div class="breadcrumb">Assessments &gt; Comparison</div>
   <div class="header"><div class="header-title">Vendor Comparison</div></div>
   <div id="comparison-output"></div>

--- a/assessments.html
+++ b/assessments.html
@@ -15,23 +15,23 @@
     .assessment-card .card-link { margin-top: 12px; display: inline-block; font-family: var(--mono); font-size: 11px; letter-spacing: .08em; text-transform: uppercase; }
   </style>
 </head>
-<body>
+<body data-page="assessments">
+<div id="nav-container"></div>
+
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+
 <div class="layout">
-  <div class="topnav">
-    <div class="topnav-label">AI Project Dashboard</div>
-    <div class="topnav-links">
-      <a class="topnav-link" href="/status-site/index.html">Dashboard</a>
-      <a class="topnav-link" href="/status-site/decisions.html">Decisions</a>
-      <a class="topnav-link" href="/status-site/scenarios.html">Scenarios</a>
-      <a class="topnav-link" href="/status-site/intelligence.html">Intelligence</a>
-      <a class="topnav-link active" href="/status-site/assessments.html">Assessments</a>
-      <a class="topnav-link" href="/status-site/artifacts.html">Artifacts</a>
-      <a class="topnav-link" href="/status-site/path-architecture.html">Architecture</a>
-      <a class="topnav-link" href="/status-site/control-plane.html">Control Plane</a>
-      <a class="topnav-link" href="/status-site/pptx-builder.html">PPTX</a>
-      <a class="topnav-link" href="/status-site/settings.html">Settings</a>
-    </div>
-  </div>
+  
 
   <div class="breadcrumb">Intelligence &gt; Vendor Assessments</div>
 

--- a/components/nav.html
+++ b/components/nav.html
@@ -1,0 +1,15 @@
+<nav class="main-nav" aria-label="Global navigation">
+  <a href="index.html" data-page="dashboard">Dashboard</a>
+  <a href="decisions.html" data-page="decisions">Decisions</a>
+  <a href="scenarios.html" data-page="scenarios">Scenarios</a>
+  <a href="intelligence.html" data-page="intelligence">Intelligence</a>
+  <a href="artifacts.html" data-page="artifacts">Artifacts</a>
+  <a href="assessments.html" data-page="assessments">Assessments</a>
+  <a href="assessments-compare.html" data-page="assessments-compare">Compare</a>
+  <a href="path-architecture.html" data-page="architecture">Architecture</a>
+  <a href="control-plane.html" data-page="control-plane">Control Plane</a>
+  <a href="kanban.html" data-page="kanban">Kanban</a>
+  <a href="pptx-builder.html" data-page="pptx">PPTX</a>
+  <a href="excalidraw-ea.html" data-page="diagram-lab">Diagram Lab</a>
+  <a href="settings.html" data-page="settings">Settings</a>
+</nav>

--- a/control-plane.html
+++ b/control-plane.html
@@ -43,22 +43,24 @@ body{background:var(--bg);color:var(--text);font-family:var(--sans);font-size:14
 .callout{border-left:3px solid var(--gold);background:rgba(249,208,48,.06);padding:14px 16px;margin-bottom:36px}.callout strong{color:#fff}.callout p{color:var(--text-dim);margin-top:6px}
 .footer{display:flex;justify-content:space-between;align-items:center;padding-top:22px;border-top:1px solid var(--border)}.footer-left,.footer-right{font-family:var(--mono);font-size:10px;color:var(--text-faint);line-height:1.8}.footer-right{text-align:right}
 </style>
+<link rel="stylesheet" href="styles.css">
 </head>
-<body>
-<div class="topnav">
-  <div class="topnav-label">AI Project Dashboard</div>
-  <div class="topnav-links">
-    <a href="/status-site/index.html">Dashboard</a>
-    <a href="/status-site/decisions.html">Decisions</a>
-    <a href="/status-site/scenarios.html">Scenarios</a>
-    <a href="/status-site/intelligence.html">Intelligence</a>
-    <a href="/status-site/artifacts.html">Artifacts</a>
-    <a href="/status-site/path-architecture.html">Architecture</a>
-    <a class="active" href="/status-site/control-plane.html">Control Plane</a>
-    <a href="/status-site/pptx-builder.html">PPTX</a>
-    <a href="/status-site/settings.html">Settings</a>
-  </div>
-</div>
+<body data-page="control-plane">
+<div id="nav-container"></div>
+
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+
+
 <div class="breadcrumb">Overview &gt; Control Plane</div>
 <div class="header">
   <div>

--- a/dashboard.html
+++ b/dashboard.html
@@ -6,14 +6,22 @@
 <title>Dashboard</title>
 <link rel="stylesheet" href="styles.css">
 </head>
-<body>
-<div class="topnav">
-<div class="topnav-label">AI Project Dashboard</div>
-<div class="topnav-links">
-<a class="topnav-link active" href="/status-site/dashboard.html">Dashboard</a>
-<a class="topnav-link" href="/status-site/intelligence.html">Intelligence</a>
-</div>
-</div>
+<body data-page="dashboard">
+<div id="nav-container"></div>
+
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+
+
 
 <div class="dashboard">
 <div id="nav"></div>

--- a/decisions.html
+++ b/decisions.html
@@ -6,21 +6,22 @@
   <title>Decision Log — AI Status Site</title>
   <link rel="stylesheet" href="styles.css">
 </head>
-<body>
-  <div class="topnav">
-    <div class="topnav-label">AI Project Dashboard</div>
-    <div class="topnav-links">
-      <a class="topnav-link" href="/status-site/index.html">Dashboard</a>
-      <a class="topnav-link active" href="/status-site/decisions.html">Decisions</a>
-      <a class="topnav-link" href="/status-site/scenarios.html">Scenarios</a>
-      <a class="topnav-link" href="/status-site/intelligence.html">Intelligence</a>
-      <a class="topnav-link" href="/status-site/artifacts.html">Artifacts</a>
-      <a class="topnav-link" href="/status-site/path-architecture.html">Architecture</a>
-      <a class="topnav-link" href="/status-site/control-plane.html">Control Plane</a>
-      <a class="topnav-link" href="/status-site/pptx-builder.html">PPTX</a>
-      <a class="topnav-link" href="/status-site/settings.html">Settings</a>
-    </div>
-  </div>
+<body data-page="decisions">
+<div id="nav-container"></div>
+
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+
+  
 
   <div class="main-container">
     <div class="left-rail">

--- a/index.html
+++ b/index.html
@@ -7,22 +7,25 @@
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=IBM+Plex+Sans:wght@300;400;600;700&family=IBM+Plex+Sans+Condensed:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
-<body>
+<body data-page="dashboard">
+<div id="nav-container"></div>
+
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+
+
+
 <div class="layout">
-  <div class="topnav">
-    <div class="topnav-label">AI Project Dashboard</div>
-    <div class="topnav-links">
-      <a class="topnav-link active" href="/status-site/index.html">Dashboard</a>
-      <a class="topnav-link" href="/status-site/decisions.html">Decisions</a>
-      <a class="topnav-link" href="/status-site/scenarios.html">Scenarios</a>
-      <a class="topnav-link" href="/status-site/intelligence.html">Intelligence</a>
-      <a class="topnav-link" href="/status-site/artifacts.html">Artifacts</a>
-      <a class="topnav-link" href="/status-site/path-architecture.html">Architecture</a>
-      <a class="topnav-link" href="/status-site/control-plane.html">Control Plane</a>
-      <a class="topnav-link" href="/status-site/pptx-builder.html">PPTX</a>
-      <a class="topnav-link" href="/status-site/settings.html">Settings</a>
-    </div>
-  </div>
+  
 
   <div class="dashboard">
     <div class="left-rail">

--- a/intelligence.html
+++ b/intelligence.html
@@ -8,21 +8,25 @@
   <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="css/editor.css">
 </head>
-<body>
+<body data-page="intelligence">
+<div id="nav-container"></div>
 
-<div class="topnav">
-  <div class="topnav-label">AI Project Dashboard</div>
-  <div class="topnav-links">
-    <a class="topnav-link" href="/status-site/index.html">Dashboard</a>
-    <a class="topnav-link" href="/status-site/decisions.html">Decisions</a>
-    <a class="topnav-link" href="/status-site/scenarios.html">Scenarios</a>
-    <a class="topnav-link active" href="/status-site/intelligence.html">Intelligence</a>
-    <a class="topnav-link" href="/status-site/artifacts.html">Artifacts</a>
-    <a class="topnav-link" href="/status-site/path-architecture.html">Architecture</a>
-    <a class="topnav-link" href="/status-site/control-plane.html">Control Plane</a>
-    <a class="topnav-link" href="/status-site/pptx-builder.html">PPTX</a>
-  </div>
-</div>
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+
+
+
+
+
 
 <div class="breadcrumb">Dashboard &gt; Intelligence &gt; Platform & Architecture</div>
 

--- a/kanban.html
+++ b/kanban.html
@@ -8,23 +8,25 @@
   <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="kanban.css">
 </head>
-<body>
+<body data-page="kanban">
+<div id="nav-container"></div>
+
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+
+
+
 <div class="layout">
-  <div class="topnav">
-    <div class="topnav-label">AI Project Dashboard</div>
-    <div class="topnav-links">
-      <a class="topnav-link" href="/status-site/index.html">Dashboard</a>
-      <a class="topnav-link" href="/status-site/decisions.html">Decisions</a>
-      <a class="topnav-link" href="/status-site/scenarios.html">Scenarios</a>
-      <a class="topnav-link" href="/status-site/intelligence.html">Intelligence</a>
-      <a class="topnav-link" href="/status-site/artifacts.html">Artifacts</a>
-      <a class="topnav-link" href="/status-site/path-architecture.html">Architecture</a>
-      <a class="topnav-link" href="/status-site/control-plane.html">Control Plane</a>
-      <a class="topnav-link" href="/status-site/pptx-builder.html">PPTX</a>
-      <a class="topnav-link active" href="/status-site/kanban.html">Kanban</a>
-      <a class="topnav-link" href="/status-site/settings.html">Settings</a>
-    </div>
-  </div>
+  
 
   <div class="breadcrumb">Dashboard &gt; Execution Board</div>
 

--- a/path-architecture.html
+++ b/path-architecture.html
@@ -73,22 +73,24 @@ h1{font-family:var(--condensed);font-size:42px;line-height:1.05;letter-spacing:.
   h1{font-size:34px}
 }
 </style>
+<link rel="stylesheet" href="styles.css">
 </head>
-<body>
-  <div class="topnav">
-    <div class="brand">AI Project Dashboard</div>
-    <div class="links">
-      <a href="/status-site/index.html">Dashboard</a>
-      <a href="/status-site/decisions.html">Decisions</a>
-      <a href="/status-site/scenarios.html">Scenarios</a>
-      <a href="/status-site/intelligence.html">Intelligence</a>
-      <a href="/status-site/artifacts.html">Artifacts</a>
-      <a class="active" href="/status-site/path-architecture.html">Architecture</a>
-      <a href="/status-site/control-plane.html">Control Plane</a>
-      <a href="/status-site/pptx-builder.html">PPTX</a>
-      <a href="/status-site/settings.html">Settings</a>
-    </div>
-  </div>
+<body data-page="architecture">
+<div id="nav-container"></div>
+
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+
+  
 
   <div class="breadcrumb">Overview &gt; PATH Architecture</div>
 

--- a/pptx-builder.html
+++ b/pptx-builder.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>PPTX Builder — PATH Status Site</title>
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=IBM+Plex+Sans:wght@300;400;600;700&family=IBM+Plex+Sans+Condensed:wght@700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="styles.css">
 <style>
 :root{--teal:#00C8C8;--red:#E8192E;--gold:#F9D030;--blue:#5FA8E8;--bg:#07090F;--bg2:#0D1117;--bg3:#131920;--surface:#1A2230;--border:rgba(255,255,255,.10);--text:#F0F4FA;--text-dim:#B0BFCF;--text-faint:#6A7D90;--mono:'IBM Plex Mono', monospace;--sans:'IBM Plex Sans', sans-serif;--cond:'IBM Plex Sans Condensed', sans-serif}
 *{box-sizing:border-box;margin:0;padding:0}
@@ -31,21 +32,24 @@ textarea{width:100%;white-space:pre-wrap;word-break:break-word;background:#0a101
 @media(max-width:980px){body{width:auto;padding:20px}.grid{grid-template-columns:1fr}}
 </style>
 </head>
-<body>
-<div class="topnav">
-  <div class="topnav-label">AI Project Dashboard</div>
-  <div class="topnav-links">
-    <a href="/status-site/index.html">Dashboard</a>
-    <a href="/status-site/decisions.html">Decisions</a>
-    <a href="/status-site/scenarios.html">Scenarios</a>
-    <a href="/status-site/intelligence.html">Intelligence</a>
-    <a href="/status-site/artifacts.html">Artifacts</a>
-    <a href="/status-site/path-architecture.html">Architecture</a>
-    <a href="/status-site/control-plane.html">Control Plane</a>
-    <a href="/status-site/pptx-builder.html" class="active">PPTX</a>
-    <a href="/status-site/settings.html">Settings</a>
-  </div>
-</div>
+<body data-page="pptx">
+<div id="nav-container"></div>
+
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+
+
+
+
 
 <div class="breadcrumb">Overview &gt; PPTX Builder</div>
 

--- a/pptx.html
+++ b/pptx.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0; url=pptx-builder.html">
+  <title>PPTX</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body data-page="pptx">
+<div id="nav-container"></div>
+
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+
+  <p>Redirecting to <a href="pptx-builder.html">PPTX Builder</a>...</p>
+</body>
+</html>

--- a/scenarios.html
+++ b/scenarios.html
@@ -6,21 +6,22 @@
   <title>Scenarios — AI Status Site</title>
   <link rel="stylesheet" href="styles.css">
 </head>
-<body>
-  <div class="topnav">
-    <div class="topnav-label">AI Project Dashboard</div>
-    <div class="topnav-links">
-      <a class="topnav-link" href="/status-site/index.html">Dashboard</a>
-      <a class="topnav-link" href="/status-site/decisions.html">Decisions</a>
-      <a class="topnav-link active" href="/status-site/scenarios.html">Scenarios</a>
-      <a class="topnav-link" href="/status-site/intelligence.html">Intelligence</a>
-      <a class="topnav-link" href="/status-site/artifacts.html">Artifacts</a>
-      <a class="topnav-link" href="/status-site/path-architecture.html">Architecture</a>
-      <a class="topnav-link" href="/status-site/control-plane.html">Control Plane</a>
-      <a class="topnav-link" href="/status-site/pptx-builder.html">PPTX</a>
-      <a class="topnav-link" href="/status-site/settings.html">Settings</a>
-    </div>
-  </div>
+<body data-page="scenarios">
+<div id="nav-container"></div>
+
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+
+  
 
   <div class="main-container">
     <div class="left-rail">

--- a/styles.css
+++ b/styles.css
@@ -914,3 +914,39 @@ body {
     font-size: 11px;
   }
 }
+
+.main-nav {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 12px 20px;
+  background: rgba(13, 17, 23, 0.96);
+  border-bottom: 1px solid #2f6f73;
+  backdrop-filter: blur(6px);
+}
+
+.main-nav a {
+  color: #d0d7da;
+  text-decoration: none;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 6px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 4px;
+}
+
+.main-nav a:hover {
+  color: #ffffff;
+  border-color: #6fc3c8;
+}
+
+.main-nav a.active {
+  color: #a6ce39;
+  border-color: #a6ce39;
+  background: rgba(166, 206, 57, 0.12);
+}


### PR DESCRIPTION
### Motivation
- Remove repeated top navigation markup across many HTML files and centralize the global navigation so updates only need to be made in one place.
- Standardize page activation and linking by using a `data-page` attribute and a single nav component to reduce duplication and maintenance burden.
- Ensure consistent styling by referencing a central `styles.css` for pages that previously embedded or omitted topnav styles.

### Description
- Add a new reusable navigation fragment `components/nav.html` and inject it at runtime using a small `fetch` script placed into each page and toggling the active link via `data-page` on the `body` element.
- Update numerous pages (including `index.html`, `dashboard.html`, `assessments*.html`, `artifacts.html`, `control-plane.html`, `intelligence.html`, `kanban.html`, `path-architecture.html`, `decisions.html`, `scenarios.html`, `pptx-builder.html`) to use `data-page` and to load `components/nav.html` instead of inline topnav markup.
- Add `pptx.html` as a lightweight redirect to `pptx-builder.html` and add `components/nav.html` usage to it.
- Link `styles.css` from pages that were missing it and extend `styles.css` with `.main-nav` styles to style the new navigation component.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8af35e5f48322b023ce0376a2411d)