### PR TITLE
Add Claude Code Assistant GitHub Actions workflow

### DIFF
--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -1,0 +1,33 @@
+name: Claude Code Assistant
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  claude-assist:
+    # Only trigger when someone mentions @claude
+    if: contains(github.event.comment.body, '@claude')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Git with Fine-grained PAT
+        run: |
+          git config --global url."https://oauth2:${{ secrets.CLAUDE_PAT }}@github.com/".insteadOf "https://github.com/"
+          git config --global user.name "Claude Assistant"
+          git config --global user.email "claude@yourorg.com"
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.CLAUDE_PAT }}
+          prompt: |
+            Analyze the code change and provide:
+            1. Security implications
+            2. Performance considerations
+            3. Suggested improvements


### PR DESCRIPTION
### Motivation
- Add a GitHub Actions workflow to invoke a Claude-based code assistant when repository comments mention `@claude` so automated analysis can provide security, performance, and improvement feedback.

### Description
- Create ` .github/workflows/claude-assistant.yml` which triggers on `issue_comment` and `pull_request_review_comment`, gates execution with `if: contains(github.event.comment.body, '@claude')`, checks out the repo, configures Git to use a fine-grained PAT via `CLAUDE_PAT`, and runs `anthropics/claude-code-action@v1` with a prompt requesting security, performance, and suggested improvements.

### Testing
- No automated tests were executed for this change since it only adds a workflow file; the file creation was validated locally and committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8ea123f748322a5d8b809c689f223)