### PR TITLE
Full nav normalization + workflow integration

### DIFF
--- a/apps/output-manager/components/nav.html
+++ b/apps/output-manager/components/nav.html
@@ -1,0 +1,17 @@
+<nav class="main-nav" aria-label="Global navigation">
+  <a href="../../index.html" data-page="dashboard">Dashboard</a>
+  <a href="../../dashboard.html" data-page="dashboard">Dashboard App</a>
+  <a href="../../decisions.html" data-page="decisions">Decisions</a>
+  <a href="../../scenarios.html" data-page="scenarios">Scenarios</a>
+  <a href="../../intelligence.html" data-page="intelligence">Intelligence</a>
+  <a href="../../artifacts.html" data-page="artifacts">Artifacts</a>
+  <a href="../../assessment.html" data-page="assessment">Assessment</a>
+  <a href="../../assessments-compare.html" data-page="assessments-compare">Compare</a>
+  <a href="../../path-architecture.html" data-page="architecture">Architecture</a>
+  <a href="../../control-plane.html" data-page="control-plane">Control Plane</a>
+  <a href="../../kanban.html" data-page="kanban">Kanban</a>
+  <a href="../../pptx-builder.html" data-page="pptx">PPTX Builder</a>
+  <a href="../../workflow/index.html" data-page="workflow">Workflow</a>
+  <a href="../../excalidraw-ea.html" data-page="diagram-lab">Diagram Lab</a>
+  <a href="../../settings.html" data-page="settings">Settings</a>
+</nav>

--- a/apps/output-manager/index.html
+++ b/apps/output-manager/index.html
@@ -6,18 +6,23 @@
   <title>Output Manager | Status Site</title>
   <link rel="stylesheet" href="styles.css" />
 </head>
-<body>
-  <header class="topbar">
+<body data-page="output-manager">
+  <div id="nav-container"></div>
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+<header class="topbar">
     <div>
       <h1>Output Manager</h1>
       <p class="subtitle">Draft blog posts, LinkedIn articles, Substack pieces, PPTX builds, and infographic artifacts in one place.</p>
     </div>
-    <nav class="topnav">
-      <a href="/status-site/">Home</a>
-      <a href="/status-site/apps/output-manager/">Output Manager</a>
-      <a href="/status-site/artifacts/">Artifacts</a>
-      <a href="/status-site/artifacts/standards/hc-phac-pptx-design-spec.md">PPTX Spec</a>
-    </nav>
   </header>
 
   <main class="layout">

--- a/architecture-switchboard.html
+++ b/architecture-switchboard.html
@@ -85,8 +85,19 @@
     }
   </style>
 </head>
-<body>
-  <header class="topbar">
+<body data-page="architecture">
+  <div id="nav-container"></div>
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+<header class="topbar">
     <div class="brand">Health Canada / PHAC — Architecture Decision Workspace</div>
     <a class="back" href="dashboard.html">← Back to dashboard</a>
   </header>

--- a/artifact-0c5aeb5a-5ee3-4dbd-97d5-20e64d9d3fa9.html
+++ b/artifact-0c5aeb5a-5ee3-4dbd-97d5-20e64d9d3fa9.html
@@ -15,7 +15,18 @@ img{max-width:100%;height:auto;border:1px solid rgba(255,255,255,.12)}
 .tag{display:inline-block;border:1px solid rgba(0,200,200,.35);color:#00C8C8;padding:4px 8px;margin:4px 6px 0 0;font-size:12px}
 </style>
 </head>
-<body>
+<body data-page="artifacts">
+<div id="nav-container"></div>
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
 <div class="eyebrow">EA Artifact</div>
 <h1>0C5Aeb5A 5Ee3 4Dbd 97D5 20E64D9D3Fa9</h1>
 <div class="meta">Diagram · 2026-04-18 · Draft</div>

--- a/artifact-579cf831-016b-4f3a-aeb6-3154a3d41cc2.html
+++ b/artifact-579cf831-016b-4f3a-aeb6-3154a3d41cc2.html
@@ -15,7 +15,18 @@ img{max-width:100%;height:auto;border:1px solid rgba(255,255,255,.12)}
 .tag{display:inline-block;border:1px solid rgba(0,200,200,.35);color:#00C8C8;padding:4px 8px;margin:4px 6px 0 0;font-size:12px}
 </style>
 </head>
-<body>
+<body data-page="artifacts">
+<div id="nav-container"></div>
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
 <div class="eyebrow">EA Artifact</div>
 <h1>579Cf831 016B 4F3A Aeb6 3154A3D41Cc2</h1>
 <div class="meta">Diagram · 2026-04-18 · Draft</div>

--- a/artifact-6808a533-6f95-493d-bfcc-0cfd050b9fab.html
+++ b/artifact-6808a533-6f95-493d-bfcc-0cfd050b9fab.html
@@ -15,7 +15,18 @@ img{max-width:100%;height:auto;border:1px solid rgba(255,255,255,.12)}
 .tag{display:inline-block;border:1px solid rgba(0,200,200,.35);color:#00C8C8;padding:4px 8px;margin:4px 6px 0 0;font-size:12px}
 </style>
 </head>
-<body>
+<body data-page="artifacts">
+<div id="nav-container"></div>
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
 <div class="eyebrow">EA Artifact</div>
 <h1>6808A533 6F95 493D Bfcc 0Cfd050B9Fab</h1>
 <div class="meta">Diagram · 2026-04-18 · Draft</div>

--- a/artifact-7d543cfc-31d0-48d3-a769-3a523f40ee1c.html
+++ b/artifact-7d543cfc-31d0-48d3-a769-3a523f40ee1c.html
@@ -15,7 +15,18 @@ img{max-width:100%;height:auto;border:1px solid rgba(255,255,255,.12)}
 .tag{display:inline-block;border:1px solid rgba(0,200,200,.35);color:#00C8C8;padding:4px 8px;margin:4px 6px 0 0;font-size:12px}
 </style>
 </head>
-<body>
+<body data-page="artifacts">
+<div id="nav-container"></div>
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
 <div class="eyebrow">EA Artifact</div>
 <h1>7D543Cfc 31D0 48D3 A769 3A523F40Ee1C</h1>
 <div class="meta">Diagram · 2026-04-18 · Draft</div>

--- a/artifact-agentic-workflow-framework-v1-test.html
+++ b/artifact-agentic-workflow-framework-v1-test.html
@@ -15,7 +15,18 @@ img{max-width:100%;height:auto;border:1px solid rgba(255,255,255,.12)}
 .tag{display:inline-block;border:1px solid rgba(0,200,200,.35);color:#00C8C8;padding:4px 8px;margin:4px 6px 0 0;font-size:12px}
 </style>
 </head>
-<body>
+<body data-page="artifacts">
+<div id="nav-container"></div>
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
 <div class="eyebrow">EA Artifact</div>
 <h1>Agentic Workflow Framework V1 Test</h1>
 <div class="meta">Diagram · 2026-04-20 · Draft</div>

--- a/artifact-agentic-workflow-framework-v1.html
+++ b/artifact-agentic-workflow-framework-v1.html
@@ -15,7 +15,18 @@ img{max-width:100%;height:auto;border:1px solid rgba(255,255,255,.12)}
 .tag{display:inline-block;border:1px solid rgba(0,200,200,.35);color:#00C8C8;padding:4px 8px;margin:4px 6px 0 0;font-size:12px}
 </style>
 </head>
-<body>
+<body data-page="artifacts">
+<div id="nav-container"></div>
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
 <div class="eyebrow">EA Artifact</div>
 <h1>Agentic Workflow Framework V1</h1>
 <div class="meta">Diagram · 2026-04-18 · Draft</div>

--- a/artifact-e66035fd-08fb-48dc-ad3d-638cdc88d5d7.html
+++ b/artifact-e66035fd-08fb-48dc-ad3d-638cdc88d5d7.html
@@ -15,7 +15,18 @@ img{max-width:100%;height:auto;border:1px solid rgba(255,255,255,.12)}
 .tag{display:inline-block;border:1px solid rgba(0,200,200,.35);color:#00C8C8;padding:4px 8px;margin:4px 6px 0 0;font-size:12px}
 </style>
 </head>
-<body>
+<body data-page="artifacts">
+<div id="nav-container"></div>
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
 <div class="eyebrow">EA Artifact</div>
 <h1>E66035Fd 08Fb 48Dc Ad3D 638Cdc88D5D7</h1>
 <div class="meta">Diagram · 2026-04-18 · Draft</div>

--- a/artifact-enterprise-automation-model-agents-bpa-rpa-hitl.html
+++ b/artifact-enterprise-automation-model-agents-bpa-rpa-hitl.html
@@ -1,7 +1,18 @@
 <!DOCTYPE html>
 <html>
 <head><title>Artifact</title></head>
-<body style="background:#07090F;color:#F0F4FA;font-family:Arial;padding:30px">
+<body style="background:#07090F;color:#F0F4FA;font-family:Arial;padding:30px" data-page="artifacts">
+<div id="nav-container"></div>
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
 <h1>Enterprise Automation Model — Agents, BPA, RPA, and Human Oversight</h1>
 <img src="artifacts/images/enterprise-automation-model-agents-bpa-rpa-hitl.jpeg" style="max-width:100%">
 <p>This artifact shows the relationship between agents, BPA, RPA, and governance layers.</p>

--- a/artifact-img-1554.html
+++ b/artifact-img-1554.html
@@ -15,7 +15,18 @@ img{max-width:100%;height:auto;border:1px solid rgba(255,255,255,.12)}
 .tag{display:inline-block;border:1px solid rgba(0,200,200,.35);color:#00C8C8;padding:4px 8px;margin:4px 6px 0 0;font-size:12px}
 </style>
 </head>
-<body>
+<body data-page="artifacts">
+<div id="nav-container"></div>
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
 <div class="eyebrow">EA Artifact</div>
 <h1>Img 1554</h1>
 <div class="meta">Diagram · 2026-04-18 · Draft</div>

--- a/artifact-readme.html
+++ b/artifact-readme.html
@@ -15,7 +15,18 @@ img{max-width:100%;height:auto;border:1px solid rgba(255,255,255,.12)}
 .tag{display:inline-block;border:1px solid rgba(0,200,200,.35);color:#00C8C8;padding:4px 8px;margin:4px 6px 0 0;font-size:12px}
 </style>
 </head>
-<body>
+<body data-page="artifacts">
+<div id="nav-container"></div>
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
 <div class="eyebrow">EA Artifact</div>
 <h1>Readme</h1>
 <div class="meta">Document · 2026-04-20 · Draft</div>

--- a/components/nav.html
+++ b/components/nav.html
@@ -11,6 +11,7 @@
   <a href="control-plane.html" data-page="control-plane">Control Plane</a>
   <a href="kanban.html" data-page="kanban">Kanban</a>
   <a href="pptx-builder.html" data-page="pptx">PPTX Builder</a>
+  <a href="workflow/index.html" data-page="workflow">Workflow</a>
   <a href="excalidraw-ea.html" data-page="diagram-lab">Diagram Lab</a>
   <a href="settings.html" data-page="settings">Settings</a>
 </nav>

--- a/excalidraw-ea.html
+++ b/excalidraw-ea.html
@@ -1,1 +1,26 @@
-(patched version with components parsing and layout omitted for brevity but implemented)
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Diagram Lab</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body data-page="diagram-lab">
+<div id="nav-container"></div>
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+<main class="layout" style="padding: 24px;">
+  <h1>Diagram Lab</h1>
+  <p>Excalidraw workspace placeholder page.</p>
+</main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -244,17 +244,5 @@ fetch('components/nav.html')
   </div>
 </div>
 
-<script>
-  document.addEventListener('DOMContentLoaded', function() {
-    const currentPage = window.location.pathname.split('/').pop() || 'index.html';
-    document.querySelectorAll('.topnav-link').forEach(link => {
-      if (link.getAttribute('href') === currentPage) {
-        link.classList.add('active');
-      } else {
-        link.classList.remove('active');
-      }
-    });
-  });
-</script>
 </body>
 </html>

--- a/intelligence.html
+++ b/intelligence.html
@@ -709,18 +709,6 @@ User approves → content integrated into intelligence page</pre>
 <script src="js/local-llm-analyzer.js"></script>
 <script src="js/intelligence-editor.js"></script>
 
-<script>
-  document.addEventListener('DOMContentLoaded', function() {
-    const currentPage = window.location.pathname.split('/').pop() || 'index.html';
-    document.querySelectorAll('.topnav-link').forEach(link => {
-      if (link.getAttribute('href') === currentPage) {
-        link.classList.add('active');
-      } else {
-        link.classList.remove('active');
-      }
-    });
-  });
-</script>
 
 </body>
 </html>

--- a/workflow/components/nav.html
+++ b/workflow/components/nav.html
@@ -1,0 +1,17 @@
+<nav class="main-nav" aria-label="Global navigation">
+  <a href="../index.html" data-page="dashboard">Dashboard</a>
+  <a href="../dashboard.html" data-page="dashboard">Dashboard App</a>
+  <a href="../decisions.html" data-page="decisions">Decisions</a>
+  <a href="../scenarios.html" data-page="scenarios">Scenarios</a>
+  <a href="../intelligence.html" data-page="intelligence">Intelligence</a>
+  <a href="../artifacts.html" data-page="artifacts">Artifacts</a>
+  <a href="../assessment.html" data-page="assessment">Assessment</a>
+  <a href="../assessments-compare.html" data-page="assessments-compare">Compare</a>
+  <a href="../path-architecture.html" data-page="architecture">Architecture</a>
+  <a href="../control-plane.html" data-page="control-plane">Control Plane</a>
+  <a href="../kanban.html" data-page="kanban">Kanban</a>
+  <a href="../pptx-builder.html" data-page="pptx">PPTX Builder</a>
+  <a href="../workflow/index.html" data-page="workflow">Workflow</a>
+  <a href="../excalidraw-ea.html" data-page="diagram-lab">Diagram Lab</a>
+  <a href="../settings.html" data-page="settings">Settings</a>
+</nav>

--- a/workflow/index.html
+++ b/workflow/index.html
@@ -29,7 +29,7 @@
 <body data-page="workflow">
 <div id="nav-container"></div>
 <script>
-fetch('../components/nav.html')
+fetch('components/nav.html')
   .then(res => res.text())
   .then(html => {
     document.getElementById('nav-container').innerHTML = html;


### PR DESCRIPTION
### Motivation
- Normalize navigation bootstrapping so every page uses a single shared nav component and consistent active-link logic.
- Remove legacy per-page `.topnav` markup and duplicated activation scripts to avoid inconsistent behavior and duplicate navs.
- Add a persistent Workflow entry in the global navigation so the workflow pages are discoverable from the main nav.
- Ensure every page carries a `data-page` attribute so the shared nav can reliably set the active link.

### Description
- Updated `components/nav.html` to include the Workflow link: `<a href="workflow/index.html" data-page="workflow">Workflow</a>` and standardized the nav markup to `nav.main-nav` with `data-page` attributes on links.
- Reworked pages to use a single bootstrapping pattern: added `data-page` on `<body>`, inserted `<div id="nav-container"></div>`, and a `fetch('components/nav.html')` loader script that sets the active link.
- Removed inline `.topnav` blocks and per-page `.topnav-link` activation scripts from pages that previously used them, replacing them with the shared loader-based activation.
- Added scoped `components/nav.html` partials for nested directories (`workflow/components/nav.html` and `apps/output-manager/components/nav.html`) and adjusted their hrefs so `fetch('components/nav.html')` resolves without broken paths, and repaired/created pages (e.g., `excalidraw-ea.html`, numerous artifact detail pages) to conform to the new pattern.

### Testing
- Ran a repository-wide check to confirm every HTML page (excluding nav partials) includes `data-page`, `id="nav-container"`, and `fetch('components/nav.html')`, which returned no errors (`errors 0`).
- Verified there is exactly one `id="nav-container"` per page with a script that populates it, using a counting script that found no duplicates. 
- Validated nav partial link targets resolve from each partial location by scanning nav `href` entries and confirming target files exist, with no missing targets reported. 
- Performed targeted `rg`/`sed` inspections of updated files (`components/nav.html`, `workflow/index.html`, `apps/output-manager/index.html`, `index.html`, `intelligence.html`, and several artifact pages) to confirm removal of legacy `.topnav` scripts and presence of the new loader pattern, all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f0db9a9c8322853f826f0dd4fae9)