### PR TITLE
Add Scenario Dashboard (Graph-based EA decision surface v1)

### DIFF
--- a/components/nav.html
+++ b/components/nav.html
@@ -2,6 +2,7 @@
   <a href="index.html" data-page="dashboard">Dashboard</a>
   <a href="decisions.html" data-page="decisions">Decisions</a>
   <a href="scenarios.html" data-page="scenarios">Scenarios</a>
+  <a href="scenario-dashboard.html" data-page="scenario-dashboard">Scenario Dashboard</a>
   <a href="intelligence.html" data-page="intelligence">Intelligence</a>
   <a href="artifacts.html" data-page="artifacts">Artifacts</a>
   <a href="assessment.html" data-page="assessment">Assessment</a>

--- a/data/scenario-presets.json
+++ b/data/scenario-presets.json
@@ -1,0 +1,32 @@
+{
+  "version": "0.1.0",
+  "presets": [
+    {
+      "id": "ottawa-heatwave",
+      "label": "Ottawa Heatwave",
+      "eventType": "Heatwave",
+      "location": "Ottawa",
+      "severity": 8,
+      "capacityThreshold": 0.85,
+      "roadSensitivity": "medium"
+    },
+    {
+      "id": "ottawa-flood",
+      "label": "Ottawa Flood",
+      "eventType": "Flood",
+      "location": "Ottawa",
+      "severity": 7,
+      "capacityThreshold": 0.8,
+      "roadSensitivity": "high"
+    },
+    {
+      "id": "gatineau-smoke",
+      "label": "Gatineau Wildfire Smoke",
+      "eventType": "Wildfire Smoke",
+      "location": "Gatineau",
+      "severity": 6,
+      "capacityThreshold": 0.85,
+      "roadSensitivity": "low"
+    }
+  ]
+}

--- a/scenario-dashboard.html
+++ b/scenario-dashboard.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scenario Dashboard</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body data-page="scenario-dashboard">
+<div id="nav-container"></div>
+<script>
+fetch('components/nav.html').then(r=>r.text()).then(html=>{
+  document.getElementById('nav-container').innerHTML=html;
+});
+</script>
+
+<div class="layout">
+  <div class="header">
+    <div class="header-eyebrow">Scenario Intelligence</div>
+    <div class="header-title">Scenario Dashboard</div>
+    <div class="header-sub">Event → Impact → Condition → Infrastructure reasoning surface.</div>
+  </div>
+
+  <div class="grid-2">
+    <div class="card">
+      <div class="card-title">Scenario Controls</div>
+      <select id="event-type"><option>Heatwave</option><option>Flood</option></select>
+      <input id="severity" type="range" min="1" max="10" value="7">
+    </div>
+
+    <div class="card">
+      <div class="card-title">Decision Output</div>
+      <div id="decision-output">Run a scenario</div>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="card-title">Subgraph Inspector</div>
+    <div id="cy" style="height:400px"></div>
+  </div>
+</div>
+
+<script src="https://unpkg.com/cytoscape@3.30.2/dist/cytoscape.min.js"></script>
+<script>
+const cy = cytoscape({
+  container: document.getElementById('cy'),
+  elements: [
+    { data:{id:'e1',label:'Heatwave',type:'event'}, position:{x:0,y:100}},
+    { data:{id:'i1',label:'Air Quality',type:'impact'}, position:{x:200,y:100}},
+    { data:{id:'c1',label:'Asthma',type:'condition'}, position:{x:400,y:100}},
+    { data:{id:'h1',label:'Hospital',type:'hospital'}, position:{x:600,y:100}},
+    { data:{source:'e1',target:'i1'}},
+    { data:{source:'i1',target:'c1'}},
+    { data:{source:'c1',target:'h1'}}
+  ],
+  style:[
+    { selector:'node', style:{label:'data(label)','background-color':'#2F6F73'}},
+    { selector:'edge', style:{'curve-style':'taxi','target-arrow-shape':'triangle'} }
+  ],
+  layout:{name:'preset'}
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
Adds a new Scenario Dashboard page introducing graph-based scenario reasoning into the EA tool.

## What’s included
- Scenario dashboard UI (scenario-dashboard.html)
- Cytoscape graph canvas (Event → Impact → Condition → Infrastructure)
- Initial scenario presets
- Navigation integration

## Why this matters
This introduces a **decision intelligence layer** beyond static comparison:
- Moves from tables → graph reasoning
- Enables scenario-based EA analysis
- Sets foundation for Neo4j + GraphRAG integration

## Next steps (not in this PR)
- Neo4j backend integration
- Dynamic subgraph retrieval
- Lane-based layout engine
- Decision trace + confidence scoring

## Risk
Low — fully additive, no existing functionality modified.

## Preview
Open:
`scenario-dashboard.html`
