### PR TITLE
Introduce shared nav component, global styles, Excalidraw Diagram Lab and encrypted Settings UI

### DIFF
--- a/artifacts.html
+++ b/artifacts.html
@@ -23,22 +23,24 @@ input::placeholder{color:var(--text-faint)}
 .card:hover{border-color:var(--teal)}
 a{color:var(--teal);text-decoration:none}
 </style>
+<link rel="stylesheet" href="styles.css">
 </head>
-<body>
-<div class="topnav">
-  <div class="topnav-label">AI Project Dashboard</div>
-  <div class="topnav-links">
-    <a class="topnav-link" href="/status-site/index.html">Dashboard</a>
-    <a class="topnav-link" href="/status-site/decisions.html">Decisions</a>
-    <a class="topnav-link" href="/status-site/scenarios.html">Scenarios</a>
-    <a class="topnav-link" href="/status-site/intelligence.html">Intelligence</a>
-    <a class="topnav-link active" href="/status-site/artifacts.html">Artifacts</a>
-    <a class="topnav-link" href="/status-site/path-architecture.html">Architecture</a>
-    <a class="topnav-link" href="/status-site/control-plane.html">Control Plane</a>
-    <a class="topnav-link" href="/status-site/pptx-builder.html">PPTX</a>
-    <a class="topnav-link" href="/status-site/settings.html">Settings</a>
-  </div>
-</div>
+<body data-page="artifacts">
+<div id="nav-container"></div>
+
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+
+
 <div class="breadcrumb">Overview &gt; EA Artifacts</div>
 <h1>EA Artifacts</h1>
 <input id="search" placeholder="Search artifacts..." onkeyup="filter()">

--- a/assessment.html
+++ b/assessment.html
@@ -7,15 +7,23 @@
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=IBM+Plex+Sans:wght@300;400;600;700&family=IBM+Plex+Sans+Condensed:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
-<body>
+<body data-page="assessment">
+<div id="nav-container"></div>
+
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+
 <div class="layout">
-  <div class="topnav">
-    <div class="topnav-label">AI Project Dashboard</div>
-    <div class="topnav-links">
-      <a class="topnav-link" href="/status-site/index.html">Dashboard</a>
-      <a class="topnav-link active" href="/status-site/assessments.html">Assessments</a>
-    </div>
-  </div>
+  
 
   <div class="breadcrumb">Assessments &gt; Detail</div>
 

--- a/assessments-compare.html
+++ b/assessments-compare.html
@@ -7,9 +7,23 @@
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=IBM+Plex+Sans:wght@300;400;600;700&family=IBM+Plex+Sans+Condensed:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
-<body>
+<body data-page="assessments-compare">
+<div id="nav-container"></div>
+
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+
 <div class="layout">
-  <div class="topnav"><div class="topnav-label">AI Project Dashboard</div></div>
+  
   <div class="breadcrumb">Assessments &gt; Comparison</div>
   <div class="header"><div class="header-title">Vendor Comparison</div></div>
   <div id="comparison-output"></div>

--- a/assessments.html
+++ b/assessments.html
@@ -15,23 +15,23 @@
     .assessment-card .card-link { margin-top: 12px; display: inline-block; font-family: var(--mono); font-size: 11px; letter-spacing: .08em; text-transform: uppercase; }
   </style>
 </head>
-<body>
+<body data-page="assessments">
+<div id="nav-container"></div>
+
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+
 <div class="layout">
-  <div class="topnav">
-    <div class="topnav-label">AI Project Dashboard</div>
-    <div class="topnav-links">
-      <a class="topnav-link" href="/status-site/index.html">Dashboard</a>
-      <a class="topnav-link" href="/status-site/decisions.html">Decisions</a>
-      <a class="topnav-link" href="/status-site/scenarios.html">Scenarios</a>
-      <a class="topnav-link" href="/status-site/intelligence.html">Intelligence</a>
-      <a class="topnav-link active" href="/status-site/assessments.html">Assessments</a>
-      <a class="topnav-link" href="/status-site/artifacts.html">Artifacts</a>
-      <a class="topnav-link" href="/status-site/path-architecture.html">Architecture</a>
-      <a class="topnav-link" href="/status-site/control-plane.html">Control Plane</a>
-      <a class="topnav-link" href="/status-site/pptx-builder.html">PPTX</a>
-      <a class="topnav-link" href="/status-site/settings.html">Settings</a>
-    </div>
-  </div>
+  
 
   <div class="breadcrumb">Intelligence &gt; Vendor Assessments</div>
 

--- a/components/nav.html
+++ b/components/nav.html
@@ -1,0 +1,16 @@
+<nav class="main-nav" aria-label="Global navigation">
+  <a href="index.html" data-page="dashboard">Dashboard</a>
+  <a href="dashboard.html" data-page="dashboard">Dashboard App</a>
+  <a href="decisions.html" data-page="decisions">Decisions</a>
+  <a href="scenarios.html" data-page="scenarios">Scenarios</a>
+  <a href="intelligence.html" data-page="intelligence">Intelligence</a>
+  <a href="artifacts.html" data-page="artifacts">Artifacts</a>
+  <a href="assessment.html" data-page="assessment">Assessment</a>
+  <a href="assessments-compare.html" data-page="assessments-compare">Compare</a>
+  <a href="path-architecture.html" data-page="architecture">Architecture</a>
+  <a href="control-plane.html" data-page="control-plane">Control Plane</a>
+  <a href="kanban.html" data-page="kanban">Kanban</a>
+  <a href="pptx-builder.html" data-page="pptx">PPTX Builder</a>
+  <a href="excalidraw-ea.html" data-page="diagram-lab">Diagram Lab</a>
+  <a href="settings.html" data-page="settings">Settings</a>
+</nav>

--- a/control-plane.html
+++ b/control-plane.html
@@ -43,22 +43,24 @@ body{background:var(--bg);color:var(--text);font-family:var(--sans);font-size:14
 .callout{border-left:3px solid var(--gold);background:rgba(249,208,48,.06);padding:14px 16px;margin-bottom:36px}.callout strong{color:#fff}.callout p{color:var(--text-dim);margin-top:6px}
 .footer{display:flex;justify-content:space-between;align-items:center;padding-top:22px;border-top:1px solid var(--border)}.footer-left,.footer-right{font-family:var(--mono);font-size:10px;color:var(--text-faint);line-height:1.8}.footer-right{text-align:right}
 </style>
+<link rel="stylesheet" href="styles.css">
 </head>
-<body>
-<div class="topnav">
-  <div class="topnav-label">AI Project Dashboard</div>
-  <div class="topnav-links">
-    <a href="/status-site/index.html">Dashboard</a>
-    <a href="/status-site/decisions.html">Decisions</a>
-    <a href="/status-site/scenarios.html">Scenarios</a>
-    <a href="/status-site/intelligence.html">Intelligence</a>
-    <a href="/status-site/artifacts.html">Artifacts</a>
-    <a href="/status-site/path-architecture.html">Architecture</a>
-    <a class="active" href="/status-site/control-plane.html">Control Plane</a>
-    <a href="/status-site/pptx-builder.html">PPTX</a>
-    <a href="/status-site/settings.html">Settings</a>
-  </div>
-</div>
+<body data-page="control-plane">
+<div id="nav-container"></div>
+
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+
+
 <div class="breadcrumb">Overview &gt; Control Plane</div>
 <div class="header">
   <div>

--- a/dashboard.html
+++ b/dashboard.html
@@ -6,14 +6,22 @@
 <title>Dashboard</title>
 <link rel="stylesheet" href="styles.css">
 </head>
-<body>
-<div class="topnav">
-<div class="topnav-label">AI Project Dashboard</div>
-<div class="topnav-links">
-<a class="topnav-link active" href="/status-site/dashboard.html">Dashboard</a>
-<a class="topnav-link" href="/status-site/intelligence.html">Intelligence</a>
-</div>
-</div>
+<body data-page="dashboard">
+<div id="nav-container"></div>
+
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+
+
 
 <div class="dashboard">
 <div id="nav"></div>

--- a/decisions.html
+++ b/decisions.html
@@ -6,21 +6,22 @@
   <title>Decision Log — AI Status Site</title>
   <link rel="stylesheet" href="styles.css">
 </head>
-<body>
-  <div class="topnav">
-    <div class="topnav-label">AI Project Dashboard</div>
-    <div class="topnav-links">
-      <a class="topnav-link" href="/status-site/index.html">Dashboard</a>
-      <a class="topnav-link active" href="/status-site/decisions.html">Decisions</a>
-      <a class="topnav-link" href="/status-site/scenarios.html">Scenarios</a>
-      <a class="topnav-link" href="/status-site/intelligence.html">Intelligence</a>
-      <a class="topnav-link" href="/status-site/artifacts.html">Artifacts</a>
-      <a class="topnav-link" href="/status-site/path-architecture.html">Architecture</a>
-      <a class="topnav-link" href="/status-site/control-plane.html">Control Plane</a>
-      <a class="topnav-link" href="/status-site/pptx-builder.html">PPTX</a>
-      <a class="topnav-link" href="/status-site/settings.html">Settings</a>
-    </div>
-  </div>
+<body data-page="decisions">
+<div id="nav-container"></div>
+
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+
+  
 
   <div class="main-container">
     <div class="left-rail">

--- a/excalidraw-ea.html
+++ b/excalidraw-ea.html
@@ -1,1 +1,380 @@
-(patched version with components parsing and layout omitted for brevity but implemented)
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>EA Diagram Lab — Excalidraw</title>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=IBM+Plex+Sans:wght@300;400;600;700&family=IBM+Plex+Sans+Condensed:wght@700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+  <style>
+    .diagram-layout{display:grid;grid-template-columns:300px 1fr;gap:20px;margin-top:20px}
+    .diagram-sidebar{border:1px solid var(--border);background:linear-gradient(160deg,var(--bg2),var(--bg3));padding:16px}
+    .diagram-stage{border:1px solid var(--border);background:var(--bg2);min-height:78vh;position:relative}
+    .diagram-stage-inner{height:78vh}
+    .tool-group{border:1px solid var(--border);padding:12px;background:rgba(255,255,255,.02);margin-bottom:12px}
+    .tool-title{font-family:var(--mono);font-size:10px;letter-spacing:.12em;text-transform:uppercase;color:var(--text-faint);margin-bottom:8px}
+    .tool-text{font-size:12px;color:var(--text-dim);line-height:1.5;margin-bottom:8px}
+    .tool-actions{display:flex;flex-wrap:wrap;gap:8px}
+    .tool-actions button,.tool-actions label{padding:8px 10px;border:1px solid var(--border-bright);background:var(--surface);color:var(--text);font-family:var(--sans);font-size:12px;cursor:pointer}
+    .tool-actions .primary{border-color:var(--teal);color:var(--teal)}
+    .tool-actions .reference{border-color:var(--gold);color:var(--gold)}
+    .tool-actions .convert{border-color:var(--blue-light);color:var(--blue-light)}
+    .status-line{font-size:11px;color:var(--text-faint);margin-top:8px}
+    .hidden-input{display:none}
+    .note-list{margin-left:18px;color:var(--text-dim)}
+    .small-note{font-size:11px;color:var(--text-faint);margin-top:8px;line-height:1.45}
+    .context-box{font-size:12px;color:var(--text-dim);line-height:1.5;background:rgba(255,255,255,.02);border:1px solid var(--border);padding:10px}
+    .context-box strong{color:var(--text)}
+    @media (max-width:980px){.diagram-layout{grid-template-columns:1fr}.diagram-stage-inner{height:70vh}}
+  </style>
+  <script>window.EXCALIDRAW_ASSET_PATH='https://unpkg.com/@excalidraw/excalidraw/dist/';</script>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script crossorigin src="https://unpkg.com/@excalidraw/excalidraw/dist/excalidraw.production.min.js"></script>
+  <script crossorigin src="https://cdn.jsdelivr.net/npm/tesseract.js@5/dist/tesseract.min.js"></script>
+</head>
+<body>
+  <div class="topnav">
+    <div class="topnav-label">AI Project Dashboard</div>
+    <div class="topnav-links">
+      <a class="topnav-link" href="/status-site/index.html">Dashboard</a>
+      <a class="topnav-link" href="/status-site/intelligence.html">Intelligence</a>
+      <a class="topnav-link" href="/status-site/artifacts.html">Artifacts</a>
+      <a class="topnav-link" href="/status-site/pptx-builder.html">PPTX</a>
+      <a class="topnav-link active" href="/status-site/excalidraw-ea.html">Diagram Lab</a>
+    </div>
+  </div>
+
+  <div class="breadcrumb">Dashboard &gt; PPTX &gt; EA Diagram Lab</div>
+
+  <div class="header">
+    <div class="header-eyebrow">Enterprise Architecture Visual Working Surface</div>
+    <div class="header-title">Excalidraw <span>EA Diagram Lab</span></div>
+    <div class="header-sub">Sketch conceptual architecture, control-plane views, capability maps, and quick ARB graphics in-browser.</div>
+    <div class="badges">
+      <div class="badge badge-teal">Excalidraw</div>
+      <div class="badge badge-gold">Reference Import</div>
+      <div class="badge badge-red">Claude Trigger Ready</div>
+    </div>
+  </div>
+
+  <div class="positioning">
+    <div class="positioning-label">Use</div>
+    <div class="positioning-text">Upload a diagram PNG, use it as a reference, or auto-initialize a starter canvas from <em>Claude slide context</em>.</div>
+  </div>
+
+  <div class="diagram-layout">
+    <div class="diagram-sidebar">
+      <div class="tool-group">
+        <div class="tool-title">Claude Context</div>
+        <div class="context-box" id="claude-context-box">No Claude trigger context detected.</div>
+      </div>
+
+      <div class="tool-group">
+        <div class="tool-title">Starter Scenes</div>
+        <div class="tool-text">Load a simple EA-oriented starter canvas.</div>
+        <div class="tool-actions">
+          <button id="btn-blank" class="primary">Blank</button>
+          <button id="btn-layered">Layered EA</button>
+          <button id="btn-control-plane">Control Plane</button>
+        </div>
+      </div>
+
+      <div class="tool-group">
+        <div class="tool-title">Reference Image</div>
+        <div class="tool-text">Upload a PNG and place it on the canvas as a locked reference image so you can redraw or annotate over it.</div>
+        <div class="tool-actions">
+          <label for="import-png" class="reference">Use PNG as Example</label>
+          <input id="import-png" class="hidden-input" type="file" accept="image/png,.png">
+        </div>
+        <div class="status-line" id="reference-status">No reference image loaded.</div>
+      </div>
+
+      <div class="tool-group">
+        <div class="tool-title">AI-Assisted Conversion</div>
+        <div class="tool-text">Run OCR and simple rectangle detection on the last PNG, then create editable Excalidraw blocks and labels.</div>
+        <div class="tool-actions">
+          <button id="btn-convert-png" class="convert">Convert PNG to EA Blocks</button>
+        </div>
+        <div class="status-line" id="convert-status">No conversion run yet.</div>
+        <div class="small-note">Best on screenshots with dark text, clear boxes, and moderate clutter.</div>
+      </div>
+
+      <div class="tool-group">
+        <div class="tool-title">File Actions</div>
+        <div class="tool-text">Save your scene in browser storage or move JSON in and out.</div>
+        <div class="tool-actions">
+          <button id="btn-save" class="primary">Save Local</button>
+          <button id="btn-export-json">Export JSON</button>
+          <label for="import-json">Import JSON</label>
+          <input id="import-json" class="hidden-input" type="file" accept="application/json,.json">
+        </div>
+        <div class="status-line" id="save-status">No local save yet.</div>
+      </div>
+
+      <div class="tool-group">
+        <div class="tool-title">EA Notes</div>
+        <ul class="note-list">
+          <li>Business / capability layer</li>
+          <li>Application / platform layer</li>
+          <li>Data / integration layer</li>
+          <li>Security / governance overlay</li>
+          <li>Directional arrows</li>
+        </ul>
+      </div>
+    </div>
+    <div class="diagram-stage"><div id="excalidraw-app" class="diagram-stage-inner"></div></div>
+  </div>
+
+  <script>
+    const STORAGE_KEY='ea_excalidraw_scene_v1';
+    let excalidrawApi=null;
+    let lastPngDataUrl=null;
+    let lastPngInfo=null;
+    let startupScene=null;
+
+    function getClaudeContext(){
+      const params = new URLSearchParams(window.location.search);
+      return {
+        template: params.get('template') || 'blank',
+        diagramKind: params.get('diagram_kind') || '',
+        slideTitle: params.get('slide_title') || '',
+        notes: params.get('notes') || ''
+      };
+    }
+
+    function renderClaudeContextBox(ctx){
+      const el = document.getElementById('claude-context-box');
+      if (!ctx.slideTitle && !ctx.diagramKind && !ctx.notes) {
+        el.textContent = 'No Claude trigger context detected.';
+        return;
+      }
+      el.innerHTML = `
+        <div><strong>Slide:</strong> ${escapeHtml(ctx.slideTitle || 'Untitled')}</div>
+        <div><strong>Diagram kind:</strong> ${escapeHtml(ctx.diagramKind || ctx.template || 'blank')}</div>
+        ${ctx.notes ? `<div style="margin-top:6px;"><strong>Notes:</strong> ${escapeHtml(ctx.notes)}</div>` : ''}
+      `;
+    }
+
+    function escapeHtml(str){
+      return String(str)
+        .replace(/&/g,'&amp;')
+        .replace(/</g,'&lt;')
+        .replace(/>/g,'&gt;')
+        .replace(/"/g,'&quot;')
+        .replace(/'/g,'&#039;');
+    }
+
+    function starterScene(kind){
+      const base={appState:{viewBackgroundColor:'#0D1117'},files:{},elements:[]};
+      if(kind==='blank') return base;
+      if(kind==='control-plane'){
+        return {...base,elements:[
+          textEl('Control Plane',80,40,28),
+          rectEl(60,100,760,90,'#00C8C8'), textEl('Identity / Policy / Audit / Cost',90,132,20),
+          rectEl(60,240,760,120,'#5FA8E8'), textEl('Runtime Plane — AI workloads / Foundry / Databricks',90,286,20),
+          rectEl(60,410,760,110,'#F9D030'), textEl('Data Layer — Purview / RAG / Integration',90,452,20)
+        ]};
+      }
+      return {...base,elements:[
+        textEl('Enterprise Architecture View',40,30,26),
+        rectEl(60,110,700,80,'#00C8C8'), textEl('Business / Capability Layer',90,138,20),
+        rectEl(60,230,700,110,'#5FA8E8'), textEl('Application / Platform Layer',90,270,20),
+        rectEl(60,380,700,110,'#F9D030'), textEl('Data / Integration Layer',90,420,20)
+      ]};
+    }
+
+    function rectEl(x,y,width,height,strokeColor,locked=false,opacity=100){return {id:crypto.randomUUID(),type:'rectangle',x,y,width,height,angle:0,strokeColor,backgroundColor:'transparent',fillStyle:'solid',strokeWidth:2,strokeStyle:'solid',roughness:0,opacity,groupIds:[],frameId:null,roundness:{type:3},seed:Math.floor(Math.random()*1e6),version:1,versionNonce:1,isDeleted:false,boundElements:null,updated:Date.now(),link:null,locked};}
+    function textEl(text,x,y,fontSize,strokeColor='#F0F4FA'){return {id:crypto.randomUUID(),type:'text',x,y,width:Math.max(120,text.length*fontSize*.56),height:fontSize*1.4,angle:0,strokeColor,backgroundColor:'transparent',fillStyle:'solid',strokeWidth:1,strokeStyle:'solid',roughness:0,opacity:100,groupIds:[],frameId:null,roundness:null,seed:Math.floor(Math.random()*1e6),version:1,versionNonce:1,isDeleted:false,boundElements:null,updated:Date.now(),link:null,locked:false,text,fontSize,fontFamily:1,textAlign:'left',verticalAlign:'top',baseline:fontSize,containerId:null,originalText:text,lineHeight:1.2};}
+
+    function buildSceneFromClaudeContext(ctx){
+      const template = ctx.template === 'layered-ea' ? 'layered' : (ctx.template || 'blank');
+      const scene = starterScene(template);
+      const extra = [];
+      if (ctx.slideTitle) {
+        extra.push(textEl(ctx.slideTitle, 40, 10, 30, '#00C8C8'));
+      }
+      if (ctx.notes) {
+        extra.push(rectEl(830, 110, 320, 180, '#5FA8E8', false, 100));
+        extra.push(textEl('Claude Notes', 850, 126, 18, '#5FA8E8'));
+        extra.push(textEl(ctx.notes, 850, 156, 16, '#F0F4FA'));
+      }
+      scene.elements = [...extra, ...scene.elements];
+      return scene;
+    }
+
+    function updateStatus(msg){document.getElementById('save-status').textContent=msg;}
+    function updateReferenceStatus(msg){document.getElementById('reference-status').textContent=msg;}
+    function updateConvertStatus(msg){document.getElementById('convert-status').textContent=msg;}
+    function saveLocal(){if(!excalidrawApi) return; const scene=excalidrawApi.getSceneElementsIncludingDeleted(); const appState=excalidrawApi.getAppState(); localStorage.setItem(STORAGE_KEY, JSON.stringify({elements:scene,appState})); updateStatus('Saved locally: '+new Date().toLocaleString());}
+    function loadLocal(){try{const raw=localStorage.getItem(STORAGE_KEY); if(!raw) return null; return JSON.parse(raw);}catch(e){return null;}}
+    function exportJson(){if(!excalidrawApi) return; const payload={elements:excalidrawApi.getSceneElementsIncludingDeleted(),appState:excalidrawApi.getAppState()}; const blob=new Blob([JSON.stringify(payload,null,2)],{type:'application/json'}); const a=document.createElement('a'); a.href=URL.createObjectURL(blob); a.download='ea-diagram-scene.json'; a.click(); URL.revokeObjectURL(a.href);} 
+    function importJson(file){const reader=new FileReader(); reader.onload=()=>{try{const data=JSON.parse(reader.result); excalidrawApi.updateScene({elements:data.elements||[],appState:data.appState||{},files:data.files||{}}); updateStatus('Imported scene: '+file.name);}catch(e){updateStatus('Import failed');}}; reader.readAsText(file);} 
+    function readAsDataURL(file){return new Promise((resolve,reject)=>{const reader=new FileReader(); reader.onload=()=>resolve(reader.result); reader.onerror=()=>reject(new Error('Failed to read PNG')); reader.readAsDataURL(file);});}
+    function loadImageInfo(dataURL){return new Promise((resolve,reject)=>{const img=new Image(); img.onload=()=>resolve({width:img.width,height:img.height,img}); img.onerror=()=>reject(new Error('Invalid PNG')); img.src=dataURL;});}
+
+    async function importPngReference(file){
+      if(!excalidrawApi) return;
+      try{
+        updateReferenceStatus('Loading PNG reference...');
+        const dataURL=await readAsDataURL(file);
+        const info=await loadImageInfo(dataURL);
+        lastPngDataUrl=dataURL;
+        lastPngInfo=info;
+        const maxWidth=1100;
+        const scale=info.width>maxWidth ? maxWidth/info.width : 1;
+        const width=Math.round(info.width*scale);
+        const height=Math.round(info.height*scale);
+        const fileId=crypto.randomUUID();
+        const imageFile={id:fileId,dataURL,mimeType:file.type||'image/png',created:Date.now(),lastRetrieved:Date.now()};
+        const imageElement={id:crypto.randomUUID(),type:'image',x:80,y:80,width,height,angle:0,strokeColor:'transparent',backgroundColor:'transparent',fillStyle:'solid',strokeWidth:1,strokeStyle:'solid',roughness:0,opacity:80,groupIds:[],frameId:null,roundness:null,seed:Math.floor(Math.random()*1e6),version:1,versionNonce:1,isDeleted:false,boundElements:null,updated:Date.now(),link:null,locked:true,fileId,scale:[1,1],status:'saved',crop:null};
+        const existing=excalidrawApi.getSceneElementsIncludingDeleted();
+        if(typeof excalidrawApi.addFiles==='function') excalidrawApi.addFiles([imageFile]);
+        excalidrawApi.updateScene({elements:[...existing,imageElement],files:{[fileId]:imageFile}});
+        updateReferenceStatus(`Reference loaded: ${file.name} (${width}×${height})`);
+        updateConvertStatus('PNG ready for conversion.');
+      }catch(error){console.error(error);updateReferenceStatus('PNG import failed.');}
+    }
+
+    function makeCanvasFromImage(img){
+      const canvas=document.createElement('canvas');
+      canvas.width=img.width; canvas.height=img.height;
+      const ctx=canvas.getContext('2d',{willReadFrequently:true});
+      ctx.drawImage(img,0,0);
+      return {canvas,ctx};
+    }
+
+    function detectRectangles(img){
+      const {canvas,ctx}=makeCanvasFromImage(img);
+      const {width,height}=canvas;
+      const data=ctx.getImageData(0,0,width,height).data;
+      const gray=new Uint8Array(width*height);
+      for(let i=0;i<width*height;i++){
+        const r=data[i*4], g=data[i*4+1], b=data[i*4+2];
+        gray[i]=(r*0.299+g*0.587+b*0.114)|0;
+      }
+      const binary=new Uint8Array(width*height);
+      for(let i=0;i<gray.length;i++) binary[i]=gray[i]<205?1:0;
+      const visited=new Uint8Array(width*height);
+      const boxes=[];
+      const minArea=Math.max(1800, Math.round(width*height*0.0008));
+      const dirs=[[1,0],[-1,0],[0,1],[0,-1]];
+      for(let y=0;y<height;y++){
+        for(let x=0;x<width;x++){
+          const idx=y*width+x;
+          if(!binary[idx]||visited[idx]) continue;
+          let q=[[x,y]], qi=0; visited[idx]=1;
+          let minX=x,maxX=x,minY=y,maxY=y,count=0;
+          while(qi<q.length){
+            const [cx,cy]=q[qi++]; count++;
+            if(cx<minX) minX=cx; if(cx>maxX) maxX=cx; if(cy<minY) minY=cy; if(cy>maxY) maxY=cy;
+            for(const [dx,dy] of dirs){
+              const nx=cx+dx, ny=cy+dy;
+              if(nx<0||ny<0||nx>=width||ny>=height) continue;
+              const nidx=ny*width+nx;
+              if(binary[nidx]&&!visited[nidx]){visited[nidx]=1; q.push([nx,ny]);}
+            }
+          }
+          const w=maxX-minX+1, h=maxY-minY+1, area=w*h;
+          if(area<minArea) continue;
+          if(w<80||h<35) continue;
+          const fill=count/area;
+          if(fill>0.35) continue;
+          if(w>width*0.96&&h>height*0.96) continue;
+          boxes.push({x:minX,y:minY,width:w,height:h,area,fill});
+        }
+      }
+      boxes.sort((a,b)=>b.area-a.area);
+      const dedup=[];
+      for(const box of boxes){
+        const overlaps=dedup.some(d=>Math.abs(d.x-box.x)<12&&Math.abs(d.y-box.y)<12&&Math.abs(d.width-box.width)<18&&Math.abs(d.height-box.height)<18);
+        if(!overlaps) dedup.push(box);
+      }
+      return dedup.slice(0,25);
+    }
+
+    async function detectTextBlocks(dataURL){
+      const result=await Tesseract.recognize(dataURL,'eng',{
+        logger:(m)=>{if(m?.status){const pct=typeof m.progress==='number'?` ${Math.round(m.progress*100)}%`:''; updateConvertStatus(`OCR: ${m.status}${pct}`);}}
+      });
+      const lines=(result.data?.lines||[]).filter(l=>l.text&&l.text.trim());
+      return {lines};
+    }
+
+    function boxContainsText(box, line){
+      const b=line.bbox||{};
+      const cx=((b.x0||0)+(b.x1||0))/2;
+      const cy=((b.y0||0)+(b.y1||0))/2;
+      return cx>=box.x && cx<=box.x+box.width && cy>=box.y && cy<=box.y+box.height;
+    }
+
+    async function convertPngToEABlocks(){
+      if(!excalidrawApi||!lastPngDataUrl||!lastPngInfo){updateConvertStatus('Load a PNG first.'); return;}
+      try{
+        updateConvertStatus('Detecting box-like shapes...');
+        const boxes=detectRectangles(lastPngInfo.img);
+        updateConvertStatus(`Detected ${boxes.length} candidate blocks. Running OCR...`);
+        const ocr=await detectTextBlocks(lastPngDataUrl);
+        const lines=ocr.lines||[];
+        const scale=Math.min(1100/lastPngInfo.width, 1);
+        const offsetX=100, offsetY=100;
+        const newElements=[];
+
+        boxes.forEach((box,idx)=>{
+          const matching=lines.filter(line=>boxContainsText(box,line));
+          const label=matching.map(m=>m.text.trim()).filter(Boolean).join(' ').replace(/\s+/g,' ').trim() || `Block ${idx+1}`;
+          const x=offsetX + Math.round(box.x*scale);
+          const y=offsetY + Math.round(box.y*scale);
+          const width=Math.max(120, Math.round(box.width*scale));
+          const height=Math.max(50, Math.round(box.height*scale));
+          newElements.push(rectEl(x,y,width,height,'#00C8C8',false,100));
+          newElements.push(textEl(label,x+14,y+14,18,'#F0F4FA'));
+        });
+
+        if(!newElements.length){updateConvertStatus('No usable blocks detected. Try a cleaner PNG.'); return;}
+
+        const existing=excalidrawApi.getSceneElementsIncludingDeleted();
+        excalidrawApi.updateScene({elements:[...existing,...newElements]});
+        updateConvertStatus(`Created ${boxes.length} EA blocks from PNG.`);
+      }catch(error){
+        console.error(error);
+        updateConvertStatus('Conversion failed.');
+      }
+    }
+
+    function applyScene(scene){
+      if(!excalidrawApi) return;
+      excalidrawApi.updateScene(scene);
+    }
+
+    function renderApp(){
+      const root=ReactDOM.createRoot(document.getElementById('excalidraw-app'));
+      const saved = loadLocal();
+      const initial = saved || startupScene || starterScene('blank');
+      root.render(React.createElement(ExcalidrawLib.Excalidraw,{initialData:initial,theme:'dark',UIOptions:{canvasActions:{saveAsImage:true}},excalidrawAPI:(api)=>{excalidrawApi=api;}}));
+    }
+
+    document.addEventListener('DOMContentLoaded',()=>{
+      const ctx = getClaudeContext();
+      renderClaudeContextBox(ctx);
+      startupScene = buildSceneFromClaudeContext(ctx);
+      renderApp();
+
+      document.getElementById('btn-save').addEventListener('click',saveLocal);
+      document.getElementById('btn-export-json').addEventListener('click',exportJson);
+      document.getElementById('btn-blank').addEventListener('click',()=>applyScene(starterScene('blank')));
+      document.getElementById('btn-layered').addEventListener('click',()=>applyScene(starterScene('layered')));
+      document.getElementById('btn-control-plane').addEventListener('click',()=>applyScene(starterScene('control-plane')));
+      document.getElementById('import-json').addEventListener('change',(e)=>{const file=e.target.files?.[0]; if(file) importJson(file); e.target.value='';});
+      document.getElementById('import-png').addEventListener('change',(e)=>{const file=e.target.files?.[0]; if(file) importPngReference(file); e.target.value='';});
+      document.getElementById('btn-convert-png').addEventListener('click',convertPngToEABlocks);
+
+      if(loadLocal()) {
+        updateStatus('Loaded local scene.');
+      } else if (ctx.slideTitle || ctx.diagramKind || ctx.notes) {
+        updateStatus('Initialized from Claude context.');
+      }
+    });
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -7,22 +7,25 @@
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=IBM+Plex+Sans:wght@300;400;600;700&family=IBM+Plex+Sans+Condensed:wght@700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
-<body>
+<body data-page="dashboard">
+<div id="nav-container"></div>
+
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+
+
+
 <div class="layout">
-  <div class="topnav">
-    <div class="topnav-label">AI Project Dashboard</div>
-    <div class="topnav-links">
-      <a class="topnav-link active" href="/status-site/index.html">Dashboard</a>
-      <a class="topnav-link" href="/status-site/decisions.html">Decisions</a>
-      <a class="topnav-link" href="/status-site/scenarios.html">Scenarios</a>
-      <a class="topnav-link" href="/status-site/intelligence.html">Intelligence</a>
-      <a class="topnav-link" href="/status-site/artifacts.html">Artifacts</a>
-      <a class="topnav-link" href="/status-site/path-architecture.html">Architecture</a>
-      <a class="topnav-link" href="/status-site/control-plane.html">Control Plane</a>
-      <a class="topnav-link" href="/status-site/pptx-builder.html">PPTX</a>
-      <a class="topnav-link" href="/status-site/settings.html">Settings</a>
-    </div>
-  </div>
+  
 
   <div class="dashboard">
     <div class="left-rail">

--- a/intelligence.html
+++ b/intelligence.html
@@ -8,21 +8,25 @@
   <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="css/editor.css">
 </head>
-<body>
+<body data-page="intelligence">
+<div id="nav-container"></div>
 
-<div class="topnav">
-  <div class="topnav-label">AI Project Dashboard</div>
-  <div class="topnav-links">
-    <a class="topnav-link" href="/status-site/index.html">Dashboard</a>
-    <a class="topnav-link" href="/status-site/decisions.html">Decisions</a>
-    <a class="topnav-link" href="/status-site/scenarios.html">Scenarios</a>
-    <a class="topnav-link active" href="/status-site/intelligence.html">Intelligence</a>
-    <a class="topnav-link" href="/status-site/artifacts.html">Artifacts</a>
-    <a class="topnav-link" href="/status-site/path-architecture.html">Architecture</a>
-    <a class="topnav-link" href="/status-site/control-plane.html">Control Plane</a>
-    <a class="topnav-link" href="/status-site/pptx-builder.html">PPTX</a>
-  </div>
-</div>
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+
+
+
+
+
 
 <div class="breadcrumb">Dashboard &gt; Intelligence &gt; Platform & Architecture</div>
 

--- a/kanban.html
+++ b/kanban.html
@@ -8,23 +8,25 @@
   <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="kanban.css">
 </head>
-<body>
+<body data-page="kanban">
+<div id="nav-container"></div>
+
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+
+
+
 <div class="layout">
-  <div class="topnav">
-    <div class="topnav-label">AI Project Dashboard</div>
-    <div class="topnav-links">
-      <a class="topnav-link" href="/status-site/index.html">Dashboard</a>
-      <a class="topnav-link" href="/status-site/decisions.html">Decisions</a>
-      <a class="topnav-link" href="/status-site/scenarios.html">Scenarios</a>
-      <a class="topnav-link" href="/status-site/intelligence.html">Intelligence</a>
-      <a class="topnav-link" href="/status-site/artifacts.html">Artifacts</a>
-      <a class="topnav-link" href="/status-site/path-architecture.html">Architecture</a>
-      <a class="topnav-link" href="/status-site/control-plane.html">Control Plane</a>
-      <a class="topnav-link" href="/status-site/pptx-builder.html">PPTX</a>
-      <a class="topnav-link active" href="/status-site/kanban.html">Kanban</a>
-      <a class="topnav-link" href="/status-site/settings.html">Settings</a>
-    </div>
-  </div>
+  
 
   <div class="breadcrumb">Dashboard &gt; Execution Board</div>
 

--- a/path-architecture.html
+++ b/path-architecture.html
@@ -73,22 +73,24 @@ h1{font-family:var(--condensed);font-size:42px;line-height:1.05;letter-spacing:.
   h1{font-size:34px}
 }
 </style>
+<link rel="stylesheet" href="styles.css">
 </head>
-<body>
-  <div class="topnav">
-    <div class="brand">AI Project Dashboard</div>
-    <div class="links">
-      <a href="/status-site/index.html">Dashboard</a>
-      <a href="/status-site/decisions.html">Decisions</a>
-      <a href="/status-site/scenarios.html">Scenarios</a>
-      <a href="/status-site/intelligence.html">Intelligence</a>
-      <a href="/status-site/artifacts.html">Artifacts</a>
-      <a class="active" href="/status-site/path-architecture.html">Architecture</a>
-      <a href="/status-site/control-plane.html">Control Plane</a>
-      <a href="/status-site/pptx-builder.html">PPTX</a>
-      <a href="/status-site/settings.html">Settings</a>
-    </div>
-  </div>
+<body data-page="architecture">
+<div id="nav-container"></div>
+
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+
+  
 
   <div class="breadcrumb">Overview &gt; PATH Architecture</div>
 

--- a/pptx-builder.html
+++ b/pptx-builder.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>PPTX Builder — PATH Status Site</title>
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=IBM+Plex+Sans:wght@300;400;600;700&family=IBM+Plex+Sans+Condensed:wght@700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="styles.css">
 <style>
 :root{--teal:#00C8C8;--red:#E8192E;--gold:#F9D030;--blue:#5FA8E8;--bg:#07090F;--bg2:#0D1117;--bg3:#131920;--surface:#1A2230;--border:rgba(255,255,255,.10);--text:#F0F4FA;--text-dim:#B0BFCF;--text-faint:#6A7D90;--mono:'IBM Plex Mono', monospace;--sans:'IBM Plex Sans', sans-serif;--cond:'IBM Plex Sans Condensed', sans-serif}
 *{box-sizing:border-box;margin:0;padding:0}
@@ -31,21 +32,24 @@ textarea{width:100%;white-space:pre-wrap;word-break:break-word;background:#0a101
 @media(max-width:980px){body{width:auto;padding:20px}.grid{grid-template-columns:1fr}}
 </style>
 </head>
-<body>
-<div class="topnav">
-  <div class="topnav-label">AI Project Dashboard</div>
-  <div class="topnav-links">
-    <a href="/status-site/index.html">Dashboard</a>
-    <a href="/status-site/decisions.html">Decisions</a>
-    <a href="/status-site/scenarios.html">Scenarios</a>
-    <a href="/status-site/intelligence.html">Intelligence</a>
-    <a href="/status-site/artifacts.html">Artifacts</a>
-    <a href="/status-site/path-architecture.html">Architecture</a>
-    <a href="/status-site/control-plane.html">Control Plane</a>
-    <a href="/status-site/pptx-builder.html" class="active">PPTX</a>
-    <a href="/status-site/settings.html">Settings</a>
-  </div>
-</div>
+<body data-page="pptx">
+<div id="nav-container"></div>
+
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+
+
+
+
 
 <div class="breadcrumb">Overview &gt; PPTX Builder</div>
 

--- a/pptx.html
+++ b/pptx.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0; url=pptx-builder.html">
+  <title>PPTX</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body data-page="pptx">
+<div id="nav-container"></div>
+
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+
+  <p>Redirecting to <a href="pptx-builder.html">PPTX Builder</a>...</p>
+</body>
+</html>

--- a/scenarios.html
+++ b/scenarios.html
@@ -6,21 +6,22 @@
   <title>Scenarios — AI Status Site</title>
   <link rel="stylesheet" href="styles.css">
 </head>
-<body>
-  <div class="topnav">
-    <div class="topnav-label">AI Project Dashboard</div>
-    <div class="topnav-links">
-      <a class="topnav-link" href="/status-site/index.html">Dashboard</a>
-      <a class="topnav-link" href="/status-site/decisions.html">Decisions</a>
-      <a class="topnav-link active" href="/status-site/scenarios.html">Scenarios</a>
-      <a class="topnav-link" href="/status-site/intelligence.html">Intelligence</a>
-      <a class="topnav-link" href="/status-site/artifacts.html">Artifacts</a>
-      <a class="topnav-link" href="/status-site/path-architecture.html">Architecture</a>
-      <a class="topnav-link" href="/status-site/control-plane.html">Control Plane</a>
-      <a class="topnav-link" href="/status-site/pptx-builder.html">PPTX</a>
-      <a class="topnav-link" href="/status-site/settings.html">Settings</a>
-    </div>
-  </div>
+<body data-page="scenarios">
+<div id="nav-container"></div>
+
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+
+  
 
   <div class="main-container">
     <div class="left-rail">

--- a/settings.html
+++ b/settings.html
@@ -1,1 +1,1062 @@
-[TRUNCATED FOR BREVITY]
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Settings — AI Project Dashboard</title>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=IBM+Plex+Sans:wght@300;400;600;700&family=IBM+Plex+Sans+Condensed:wght@700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+  <style>
+    /* Settings-specific styles */
+    .settings-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 24px;
+    }
+
+    .settings-section {
+      border: 1px solid var(--border);
+      background: linear-gradient(160deg, var(--bg2), var(--bg3));
+      padding: 24px;
+      animation: fade-in 0.3s ease-out;
+    }
+
+    .settings-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 16px;
+      padding-bottom: 12px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .settings-title {
+      font-family: var(--cond);
+      font-size: 18px;
+      font-weight: 700;
+      color: var(--text);
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .toggle-switch {
+      position: relative;
+      display: inline-block;
+      width: 48px;
+      height: 24px;
+    }
+
+    .toggle-switch input {
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
+
+    .toggle-slider {
+      position: absolute;
+      cursor: pointer;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background: var(--text-faint);
+      transition: 0.3s;
+      border-radius: 24px;
+      border: 1px solid var(--border);
+    }
+
+    .toggle-slider:before {
+      position: absolute;
+      content: "";
+      height: 18px;
+      width: 18px;
+      left: 2px;
+      bottom: 2px;
+      background: white;
+      transition: 0.3s;
+      border-radius: 50%;
+    }
+
+    input:checked + .toggle-slider {
+      background: var(--teal);
+      border-color: var(--teal);
+    }
+
+    input:checked + .toggle-slider:before {
+      transform: translateX(24px);
+    }
+
+    .form-group {
+      margin-bottom: 16px;
+    }
+
+    .form-label {
+      display: block;
+      font-family: var(--mono);
+      font-size: 11px;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--text-faint);
+      margin-bottom: 6px;
+    }
+
+    .form-input,
+    .form-select,
+    .form-textarea {
+      width: 100%;
+      padding: 10px 12px;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      color: var(--text);
+      font-family: var(--mono);
+      font-size: 13px;
+      transition: all 0.15s;
+      border-radius: 3px;
+    }
+
+    .form-input:focus,
+    .form-select:focus,
+    .form-textarea:focus {
+      outline: none;
+      border-color: var(--teal);
+      box-shadow: 0 0 0 2px rgba(0, 200, 200, 0.1);
+    }
+
+    .form-textarea {
+      resize: vertical;
+      min-height: 80px;
+    }
+
+    .form-row {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 16px;
+    }
+
+    .form-row.full {
+      grid-template-columns: 1fr;
+    }
+
+    .button-group {
+      display: flex;
+      gap: 8px;
+      margin-top: 16px;
+    }
+
+    .btn {
+      padding: 10px 16px;
+      font-family: var(--mono);
+      font-size: 11px;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      border: 1px solid var(--border);
+      background: rgba(255, 255, 255, 0.05);
+      color: var(--text);
+      cursor: pointer;
+      transition: all 0.15s;
+      border-radius: 3px;
+      white-space: nowrap;
+    }
+
+    .btn:hover {
+      border-color: var(--text);
+      background: rgba(255, 255, 255, 0.1);
+    }
+
+    .btn-primary {
+      border-color: var(--teal);
+      color: var(--teal);
+      background: rgba(0, 200, 200, 0.05);
+    }
+
+    .btn-primary:hover {
+      border-color: var(--teal);
+      background: rgba(0, 200, 200, 0.15);
+    }
+
+    .btn-danger {
+      border-color: var(--red);
+      color: var(--red);
+    }
+
+    .btn-danger:hover {
+      background: rgba(232, 25, 46, 0.1);
+    }
+
+    .btn-small {
+      padding: 6px 10px;
+      font-size: 10px;
+    }
+
+    .item-list {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      margin-top: 12px;
+    }
+
+    .item-card {
+      border: 1px solid var(--border);
+      background: var(--bg);
+      padding: 12px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      border-radius: 3px;
+      transition: all 0.15s;
+    }
+
+    .item-card:hover {
+      border-color: var(--teal);
+      background: var(--bg2);
+    }
+
+    .item-card-content {
+      flex: 1;
+    }
+
+    .item-label {
+      font-weight: 600;
+      color: var(--text);
+      font-size: 13px;
+    }
+
+    .item-sub {
+      font-size: 12px;
+      color: var(--text-faint);
+      margin-top: 4px;
+      word-break: break-all;
+    }
+
+    .item-actions {
+      display: flex;
+      gap: 6px;
+    }
+
+    .alert {
+      padding: 12px 14px;
+      border-radius: 3px;
+      font-size: 12px;
+      margin-bottom: 16px;
+      display: none;
+    }
+
+    .alert.show {
+      display: block;
+    }
+
+    .alert-success {
+      border: 1px solid var(--green);
+      background: rgba(124, 255, 178, 0.08);
+      color: var(--green);
+    }
+
+    .alert-error {
+      border: 1px solid var(--red);
+      background: rgba(232, 25, 46, 0.08);
+      color: var(--red);
+    }
+
+    .info-text {
+      font-size: 12px;
+      color: var(--text-faint);
+      margin-top: 8px;
+      padding: 10px;
+      background: rgba(255, 255, 255, 0.03);
+      border-left: 2px solid var(--text-faint);
+      border-radius: 2px;
+    }
+
+    .encryption-status {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 12px;
+      padding: 6px 10px;
+      background: rgba(0, 200, 200, 0.1);
+      border: 1px solid var(--teal);
+      border-radius: 3px;
+      color: var(--teal);
+    }
+
+    .status-indicator {
+      width: 6px;
+      height: 6px;
+      background: var(--teal);
+      border-radius: 50%;
+      animation: pulse 2s infinite;
+    }
+
+    .collapse-button {
+      background: none;
+      border: none;
+      color: var(--teal);
+      cursor: pointer;
+      font-size: 12px;
+      padding: 0;
+      font-family: var(--mono);
+    }
+
+    .collapse-content {
+      max-height: 0;
+      overflow: hidden;
+      transition: max-height 0.3s ease-out;
+    }
+
+    .collapse-content.expanded {
+      max-height: 500px;
+    }
+  </style>
+</head>
+<body data-page="settings">
+<div id="nav-container"></div>
+
+<script>
+fetch('components/nav.html')
+  .then(res => res.text())
+  .then(html => {
+    document.getElementById('nav-container').innerHTML = html;
+
+    const page = document.body.dataset.page;
+    document.querySelector(`[data-page="${page}"]`)?.classList.add('active');
+  })
+  .catch(() => {});
+</script>
+
+<div class="layout">
+  
+
+  <div class="dashboard" style="grid-template-columns: 1fr;">
+    <div class="main-content" style="grid-column: 1;">
+      <div class="breadcrumb">Dashboard &gt; Settings</div>
+
+      <div class="header">
+        <div class="header-eyebrow">Configuration & Security</div>
+        <div class="header-title">Settings</div>
+        <div class="header-sub">Manage API keys, MCP servers, model memory, and skills with encrypted local storage.</div>
+      </div>
+
+      <div id="alertContainer"></div>
+
+      <div class="positioning">
+        <div class="positioning-label">Status</div>
+        <div class="positioning-text">
+          <div class="encryption-status">
+            <div class="status-indicator"></div>
+            Local encryption enabled · Data stored in browser
+          </div>
+        </div>
+      </div>
+
+      <div class="settings-grid">
+        <!-- API Keys Section -->
+        <div class="settings-section">
+          <div class="settings-header">
+            <div class="settings-title">🔑 API Keys</div>
+            <label class="toggle-switch">
+              <input type="checkbox" id="keysToggle" checked>
+              <span class="toggle-slider"></span>
+            </label>
+          </div>
+          <div class="collapse-content expanded" id="keysCollapse">
+            <p class="info-text">Secure API keys for Claude, Anthropic, and third-party services. Keys are encrypted locally.</p>
+
+            <div class="form-group">
+              <label class="form-label">Service Name</label>
+              <input type="text" id="keyName" class="form-input" placeholder="e.g., Claude API, OpenAI">
+            </div>
+
+            <div class="form-group">
+              <label class="form-label">API Key</label>
+              <input type="password" id="keyValue" class="form-input" placeholder="sk-...">
+            </div>
+
+            <div class="form-group">
+              <label class="form-label">Description (optional)</label>
+              <input type="text" id="keyDesc" class="form-input" placeholder="Purpose or environment">
+            </div>
+
+            <div class="button-group">
+              <button class="btn btn-primary" onclick="addApiKey()">Add Key</button>
+            </div>
+
+            <div class="item-list" id="keysList"></div>
+          </div>
+        </div>
+
+        <!-- MCP Servers Section -->
+        <div class="settings-section">
+          <div class="settings-header">
+            <div class="settings-title">🌐 MCP Servers</div>
+            <label class="toggle-switch">
+              <input type="checkbox" id="mcpToggle" checked>
+              <span class="toggle-slider"></span>
+            </label>
+          </div>
+          <div class="collapse-content expanded" id="mcpCollapse">
+            <p class="info-text">Configure Model Context Protocol servers for tool integration and extensions.</p>
+
+            <div class="form-group">
+              <label class="form-label">Server Name</label>
+              <input type="text" id="mcpName" class="form-input" placeholder="e.g., GitHub MCP">
+            </div>
+
+            <div class="form-row">
+              <div class="form-group">
+                <label class="form-label">Protocol</label>
+                <select id="mcpProtocol" class="form-select">
+                  <option value="http">HTTP</option>
+                  <option value="https">HTTPS</option>
+                  <option value="ws">WebSocket</option>
+                  <option value="stdio">StdIO</option>
+                </select>
+              </div>
+              <div class="form-group">
+                <label class="form-label">URL / Path</label>
+                <input type="text" id="mcpUrl" class="form-input" placeholder="localhost:3000 or /path/to/server">
+              </div>
+            </div>
+
+            <div class="form-group">
+              <label class="form-label">Authentication (optional)</label>
+              <input type="text" id="mcpAuth" class="form-input" placeholder="Bearer token or credentials">
+            </div>
+
+            <div class="button-group">
+              <button class="btn btn-primary" onclick="addMcpServer()">Add Server</button>
+            </div>
+
+            <div class="item-list" id="mcpList"></div>
+          </div>
+        </div>
+
+        <!-- Model Memory Section -->
+        <div class="settings-section">
+          <div class="settings-header">
+            <div class="settings-title">🧠 Model Memory</div>
+            <label class="toggle-switch">
+              <input type="checkbox" id="memoryToggle" checked>
+              <span class="toggle-slider"></span>
+            </label>
+          </div>
+          <div class="collapse-content expanded" id="memoryCollapse">
+            <p class="info-text">Persistent memory configurations for AI models—context windows, system prompts, and knowledge bases.</p>
+
+            <div class="form-group">
+              <label class="form-label">Memory Name</label>
+              <input type="text" id="memoryName" class="form-input" placeholder="e.g., User Context, System Instructions">
+            </div>
+
+            <div class="form-group">
+              <label class="form-label">Model</label>
+              <input type="text" id="memoryModel" class="form-input" placeholder="e.g., claude-opus-4-7, gpt-4">
+            </div>
+
+            <div class="form-group">
+              <label class="form-label">Content</label>
+              <textarea id="memoryContent" class="form-textarea" placeholder="Context, system prompt, or knowledge base content..."></textarea>
+            </div>
+
+            <div class="form-row">
+              <div class="form-group">
+                <label class="form-label">Token Limit</label>
+                <input type="number" id="memoryTokens" class="form-input" placeholder="4000">
+              </div>
+              <div class="form-group">
+                <label class="form-label">Priority</label>
+                <select id="memoryPriority" class="form-select">
+                  <option value="high">High</option>
+                  <option value="medium" selected>Medium</option>
+                  <option value="low">Low</option>
+                </select>
+              </div>
+            </div>
+
+            <div class="button-group">
+              <button class="btn btn-primary" onclick="addMemory()">Add Memory</button>
+            </div>
+
+            <div class="item-list" id="memoryList"></div>
+          </div>
+        </div>
+
+        <!-- Skills Section -->
+        <div class="settings-section">
+          <div class="settings-header">
+            <div class="settings-title">⚙️ Skills</div>
+            <label class="toggle-switch">
+              <input type="checkbox" id="skillsToggle" checked>
+              <span class="toggle-slider"></span>
+            </label>
+          </div>
+          <div class="collapse-content expanded" id="skillsCollapse">
+            <p class="info-text">Define custom skills and capabilities available to Claude Code agents.</p>
+
+            <div class="form-group">
+              <label class="form-label">Skill Name</label>
+              <input type="text" id="skillName" class="form-input" placeholder="e.g., code-review, deploy-app">
+            </div>
+
+            <div class="form-group">
+              <label class="form-label">Trigger Pattern</label>
+              <input type="text" id="skillTrigger" class="form-input" placeholder="/my-skill or skill-name">
+            </div>
+
+            <div class="form-group">
+              <label class="form-label">Description</label>
+              <textarea id="skillDesc" class="form-textarea" placeholder="What this skill does and when to use it..."></textarea>
+            </div>
+
+            <div class="form-group">
+              <label class="form-label">Command / Script</label>
+              <textarea id="skillCommand" class="form-textarea" placeholder="bash script, python, or invoke command..."></textarea>
+            </div>
+
+            <div class="form-row">
+              <div class="form-group">
+                <label class="form-label">Category</label>
+                <input type="text" id="skillCategory" class="form-input" placeholder="e.g., development, infrastructure">
+              </div>
+              <div class="form-group">
+                <label class="form-label">Enabled</label>
+                <label class="toggle-switch" style="margin-top: 4px;">
+                  <input type="checkbox" id="skillEnabled" checked>
+                  <span class="toggle-slider"></span>
+                </label>
+              </div>
+            </div>
+
+            <div class="button-group">
+              <button class="btn btn-primary" onclick="addSkill()">Add Skill</button>
+            </div>
+
+            <div class="item-list" id="skillsList"></div>
+          </div>
+        </div>
+
+        <!-- Data Management Section -->
+        <div class="settings-section">
+          <div class="settings-header">
+            <div class="settings-title">💾 Data Management</div>
+          </div>
+
+          <p class="info-text">All data is encrypted and stored locally in your browser. Use these controls to manage your configuration.</p>
+
+          <div class="form-group" style="margin-top: 16px;">
+            <label class="form-label">Encryption Passphrase</label>
+            <input type="password" id="passphrase" class="form-input" placeholder="Create or update encryption passphrase">
+            <div class="info-text" style="margin-top: 8px;">Leave blank to use default. Change this to add an extra layer of security.</div>
+          </div>
+
+          <div class="button-group">
+            <button class="btn" onclick="exportSettings()">Export Settings (JSON)</button>
+            <button class="btn" onclick="importSettings()">Import Settings</button>
+            <button class="btn btn-danger" onclick="clearAllSettings()">Clear All Data</button>
+          </div>
+
+          <input type="file" id="importFile" style="display: none;" accept=".json">
+        </div>
+
+        <!-- About Section -->
+        <div class="settings-section">
+          <div class="settings-header">
+            <div class="settings-title">ℹ️ About Settings</div>
+          </div>
+
+          <p style="color: var(--text-dim); line-height: 1.65;">
+            This settings page provides secure, local management of your API keys, MCP servers, model memory, and custom skills.
+            All data is encrypted using your browser's Web Crypto API and stored in local storage—nothing is sent to external servers.
+          </p>
+
+          <p style="color: var(--text-faint); margin-top: 12px; font-size: 12px;">
+            <strong>Privacy:</strong> Your configuration is only stored on this device. Clear browser data to delete all settings.
+          </p>
+
+          <p style="color: var(--text-faint); margin-top: 8px; font-size: 12px;">
+            <strong>Backup:</strong> Periodically export your settings to keep a secure backup.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="footer">
+    <div class="footer-left">
+      AI Project Dashboard — Settings<br>
+      <span id="version">Version 1.0 · April 2026</span>
+    </div>
+    <div class="footer-right">
+      <span id="last-updated">Last updated: 2026-04-20</span>
+    </div>
+  </div>
+</div>
+
+<script>
+  // ============================================
+  // Encryption & Storage Management
+  // ============================================
+
+  const STORAGE_KEY = 'ai_dashboard_config';
+  const PASSPHRASE_KEY = 'ai_dashboard_passphrase_salt';
+
+  class SecureStorage {
+    static async encrypt(data, passphrase = null) {
+      const phrase = passphrase || 'default-encryption-key-2026';
+      const encoder = new TextEncoder();
+      const dataStr = JSON.stringify(data);
+
+      try {
+        const keyMaterial = await window.crypto.subtle.importKey(
+          'raw',
+          encoder.encode(phrase),
+          { name: 'PBKDF2' },
+          false,
+          ['deriveBits', 'deriveKey']
+        );
+
+        const key = await window.crypto.subtle.deriveKey(
+          { name: 'PBKDF2', salt: encoder.encode('salt2026'), iterations: 100000, hash: 'SHA-256' },
+          keyMaterial,
+          { name: 'AES-GCM', length: 256 },
+          false,
+          ['encrypt']
+        );
+
+        const iv = window.crypto.getRandomValues(new Uint8Array(12));
+        const encrypted = await window.crypto.subtle.encrypt('AES-GCM', key, encoder.encode(dataStr));
+
+        const encryptedData = new Uint8Array(iv.length + encrypted.byteLength);
+        encryptedData.set(iv);
+        encryptedData.set(new Uint8Array(encrypted), iv.length);
+
+        return btoa(String.fromCharCode.apply(null, encryptedData));
+      } catch (error) {
+        console.error('Encryption error:', error);
+        return null;
+      }
+    }
+
+    static async decrypt(encryptedStr, passphrase = null) {
+      const phrase = passphrase || 'default-encryption-key-2026';
+      const encoder = new TextEncoder();
+
+      try {
+        const binaryStr = atob(encryptedStr);
+        const encryptedData = new Uint8Array(binaryStr.length);
+        for (let i = 0; i < binaryStr.length; i++) {
+          encryptedData[i] = binaryStr.charCodeAt(i);
+        }
+
+        const iv = encryptedData.slice(0, 12);
+        const encrypted = encryptedData.slice(12);
+
+        const keyMaterial = await window.crypto.subtle.importKey(
+          'raw',
+          encoder.encode(phrase),
+          { name: 'PBKDF2' },
+          false,
+          ['deriveBits', 'deriveKey']
+        );
+
+        const key = await window.crypto.subtle.deriveKey(
+          { name: 'PBKDF2', salt: encoder.encode('salt2026'), iterations: 100000, hash: 'SHA-256' },
+          keyMaterial,
+          { name: 'AES-GCM', length: 256 },
+          false,
+          ['decrypt']
+        );
+
+        const decrypted = await window.crypto.subtle.decrypt('AES-GCM', key, encrypted.buffer);
+        return JSON.parse(new TextDecoder().decode(decrypted));
+      } catch (error) {
+        console.error('Decryption error:', error);
+        return null;
+      }
+    }
+
+    static save(data, passphrase = null) {
+      const encrypted = SecureStorage.encrypt(data, passphrase);
+      if (encrypted) {
+        localStorage.setItem(STORAGE_KEY, encrypted);
+        return true;
+      }
+      return false;
+    }
+
+    static async load(passphrase = null) {
+      const encrypted = localStorage.getItem(STORAGE_KEY);
+      if (!encrypted) return null;
+      return await SecureStorage.decrypt(encrypted, passphrase);
+    }
+  }
+
+  // ============================================
+  // Data Management
+  // ============================================
+
+  let config = {
+    keys: [],
+    mcpServers: [],
+    memory: [],
+    skills: []
+  };
+
+  async function loadConfig() {
+    const loaded = await SecureStorage.load();
+    if (loaded) {
+      config = loaded;
+      renderAllLists();
+    }
+  }
+
+  async function saveConfig() {
+    const passphrase = document.getElementById('passphrase').value || null;
+    await SecureStorage.encrypt(config, passphrase);
+    localStorage.setItem(STORAGE_KEY, await SecureStorage.encrypt(config, passphrase));
+    showAlert('Settings saved successfully', 'success');
+    updateTimestamp();
+  }
+
+  // ============================================
+  // API Keys
+  // ============================================
+
+  async function addApiKey() {
+    const name = document.getElementById('keyName').value.trim();
+    const value = document.getElementById('keyValue').value.trim();
+    const desc = document.getElementById('keyDesc').value.trim();
+
+    if (!name || !value) {
+      showAlert('Please provide both service name and API key', 'error');
+      return;
+    }
+
+    config.keys.push({
+      id: Date.now(),
+      name,
+      value: await SecureStorage.encrypt({ key: value }),
+      description: desc,
+      created: new Date().toISOString()
+    });
+
+    document.getElementById('keyName').value = '';
+    document.getElementById('keyValue').value = '';
+    document.getElementById('keyDesc').value = '';
+
+    await saveConfig();
+    renderKeysList();
+  }
+
+  function renderKeysList() {
+    const list = document.getElementById('keysList');
+    list.innerHTML = '';
+
+    config.keys.forEach(key => {
+      const card = document.createElement('div');
+      card.className = 'item-card';
+      const maskedKey = '•'.repeat(Math.min(key.value.length - 8, 12)) + key.value.slice(-4);
+      card.innerHTML = `
+        <div class="item-card-content">
+          <div class="item-label">${key.name}</div>
+          <div class="item-sub">Key: ${maskedKey}${key.description ? ' | ' + key.description : ''}</div>
+        </div>
+        <div class="item-actions">
+          <button class="btn btn-small" onclick="deleteKey(${key.id})">Delete</button>
+        </div>
+      `;
+      list.appendChild(card);
+    });
+  }
+
+  function deleteKey(id) {
+    config.keys = config.keys.filter(k => k.id !== id);
+    saveConfig();
+  }
+
+  // ============================================
+  // MCP Servers
+  // ============================================
+
+  function addMcpServer() {
+    const name = document.getElementById('mcpName').value.trim();
+    const protocol = document.getElementById('mcpProtocol').value;
+    const url = document.getElementById('mcpUrl').value.trim();
+    const auth = document.getElementById('mcpAuth').value.trim();
+
+    if (!name || !url) {
+      showAlert('Please provide server name and URL', 'error');
+      return;
+    }
+
+    config.mcpServers.push({
+      id: Date.now(),
+      name,
+      protocol,
+      url,
+      auth: auth || null,
+      created: new Date().toISOString()
+    });
+
+    document.getElementById('mcpName').value = '';
+    document.getElementById('mcpUrl').value = '';
+    document.getElementById('mcpAuth').value = '';
+
+    saveConfig();
+    renderMcpList();
+  }
+
+  function renderMcpList() {
+    const list = document.getElementById('mcpList');
+    list.innerHTML = '';
+
+    config.mcpServers.forEach(server => {
+      const card = document.createElement('div');
+      card.className = 'item-card';
+      card.innerHTML = `
+        <div class="item-card-content">
+          <div class="item-label">${server.name}</div>
+          <div class="item-sub">${server.protocol.toUpperCase()} → ${server.url}${server.auth ? ' (authenticated)' : ''}</div>
+        </div>
+        <div class="item-actions">
+          <button class="btn btn-small" onclick="deleteMcpServer(${server.id})">Delete</button>
+        </div>
+      `;
+      list.appendChild(card);
+    });
+  }
+
+  function deleteMcpServer(id) {
+    config.mcpServers = config.mcpServers.filter(s => s.id !== id);
+    saveConfig();
+  }
+
+  // ============================================
+  // Model Memory
+  // ============================================
+
+  function addMemory() {
+    const name = document.getElementById('memoryName').value.trim();
+    const model = document.getElementById('memoryModel').value.trim();
+    const content = document.getElementById('memoryContent').value.trim();
+    const tokens = document.getElementById('memoryTokens').value;
+    const priority = document.getElementById('memoryPriority').value;
+
+    if (!name || !content) {
+      showAlert('Please provide memory name and content', 'error');
+      return;
+    }
+
+    config.memory.push({
+      id: Date.now(),
+      name,
+      model: model || 'general',
+      content,
+      tokens: tokens ? parseInt(tokens) : 4000,
+      priority,
+      created: new Date().toISOString()
+    });
+
+    document.getElementById('memoryName').value = '';
+    document.getElementById('memoryModel').value = '';
+    document.getElementById('memoryContent').value = '';
+    document.getElementById('memoryTokens').value = '';
+
+    saveConfig();
+    renderMemoryList();
+  }
+
+  function renderMemoryList() {
+    const list = document.getElementById('memoryList');
+    list.innerHTML = '';
+
+    config.memory.forEach(mem => {
+      const card = document.createElement('div');
+      card.className = 'item-card';
+      const preview = mem.content.substring(0, 60) + (mem.content.length > 60 ? '...' : '');
+      card.innerHTML = `
+        <div class="item-card-content">
+          <div class="item-label">${mem.name} <span style="color: var(--text-faint); font-weight: normal;">[${mem.priority.toUpperCase()}]</span></div>
+          <div class="item-sub">Model: ${mem.model} | Tokens: ${mem.tokens} | ${preview}</div>
+        </div>
+        <div class="item-actions">
+          <button class="btn btn-small" onclick="deleteMemory(${mem.id})">Delete</button>
+        </div>
+      `;
+      list.appendChild(card);
+    });
+  }
+
+  function deleteMemory(id) {
+    config.memory = config.memory.filter(m => m.id !== id);
+    saveConfig();
+  }
+
+  // ============================================
+  // Skills
+  // ============================================
+
+  function addSkill() {
+    const name = document.getElementById('skillName').value.trim();
+    const trigger = document.getElementById('skillTrigger').value.trim();
+    const desc = document.getElementById('skillDesc').value.trim();
+    const command = document.getElementById('skillCommand').value.trim();
+    const category = document.getElementById('skillCategory').value.trim();
+    const enabled = document.getElementById('skillEnabled').checked;
+
+    if (!name || !trigger) {
+      showAlert('Please provide skill name and trigger pattern', 'error');
+      return;
+    }
+
+    config.skills.push({
+      id: Date.now(),
+      name,
+      trigger,
+      description: desc,
+      command,
+      category: category || 'general',
+      enabled,
+      created: new Date().toISOString()
+    });
+
+    document.getElementById('skillName').value = '';
+    document.getElementById('skillTrigger').value = '';
+    document.getElementById('skillDesc').value = '';
+    document.getElementById('skillCommand').value = '';
+    document.getElementById('skillCategory').value = '';
+
+    saveConfig();
+    renderSkillsList();
+  }
+
+  function renderSkillsList() {
+    const list = document.getElementById('skillsList');
+    list.innerHTML = '';
+
+    config.skills.forEach(skill => {
+      const card = document.createElement('div');
+      card.className = 'item-card';
+      const status = skill.enabled ? '✓ Active' : '✗ Inactive';
+      card.innerHTML = `
+        <div class="item-card-content">
+          <div class="item-label">${skill.name} <span style="color: var(--text-faint); font-weight: normal;">[${skill.trigger}]</span></div>
+          <div class="item-sub">Category: ${skill.category} | ${status}${skill.description ? ' | ' + skill.description.substring(0, 40) + '...' : ''}</div>
+        </div>
+        <div class="item-actions">
+          <button class="btn btn-small" onclick="deleteSkill(${skill.id})">Delete</button>
+        </div>
+      `;
+      list.appendChild(card);
+    });
+  }
+
+  function deleteSkill(id) {
+    config.skills = config.skills.filter(s => s.id !== id);
+    saveConfig();
+  }
+
+  // ============================================
+  // Render All
+  // ============================================
+
+  function renderAllLists() {
+    renderKeysList();
+    renderMcpList();
+    renderMemoryList();
+    renderSkillsList();
+  }
+
+  // ============================================
+  // Toggles
+  // ============================================
+
+  document.addEventListener('DOMContentLoaded', function() {
+    loadConfig();
+
+    ['keys', 'mcp', 'memory', 'skills'].forEach(section => {
+      const toggle = document.getElementById(section + 'Toggle');
+      const collapse = document.getElementById(section + 'Collapse');
+
+      toggle.addEventListener('change', function() {
+        if (this.checked) {
+          collapse.classList.add('expanded');
+        } else {
+          collapse.classList.remove('expanded');
+        }
+      });
+    });
+
+  });
+
+  // ============================================
+  // Export/Import/Clear
+  // ============================================
+
+  function exportSettings() {
+    const dataStr = JSON.stringify(config, null, 2);
+    const dataBlob = new Blob([dataStr], { type: 'application/json' });
+    const url = URL.createObjectURL(dataBlob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `ai-dashboard-settings-${new Date().toISOString().split('T')[0]}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  function importSettings() {
+    document.getElementById('importFile').click();
+  }
+
+  document.getElementById('importFile').addEventListener('change', function(e) {
+    const file = e.target.files[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = function(event) {
+      try {
+        const imported = JSON.parse(event.target.result);
+        config = imported;
+        saveConfig();
+        renderAllLists();
+        showAlert('Settings imported successfully', 'success');
+      } catch (error) {
+        showAlert('Invalid settings file', 'error');
+      }
+    };
+    reader.readAsText(file);
+  });
+
+  function clearAllSettings() {
+    if (confirm('Are you sure? This will delete ALL your settings, keys, and custom configurations. This action cannot be undone.')) {
+      localStorage.removeItem(STORAGE_KEY);
+      config = { keys: [], mcpServers: [], memory: [], skills: [] };
+      renderAllLists();
+      showAlert('All settings cleared', 'success');
+    }
+  }
+
+  // ============================================
+  // Utilities
+  // ============================================
+
+  function showAlert(message, type) {
+    const container = document.getElementById('alertContainer');
+    const alert = document.createElement('div');
+    alert.className = `alert alert-${type} show`;
+    alert.textContent = message;
+    container.innerHTML = '';
+    container.appendChild(alert);
+
+    setTimeout(() => {
+      alert.classList.remove('show');
+    }, 4000);
+  }
+
+  function updateTimestamp() {
+    document.getElementById('last-updated').textContent = 'Last updated: ' + new Date().toLocaleString();
+  }
+</script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -914,3 +914,39 @@ body {
     font-size: 11px;
   }
 }
+
+.main-nav {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 12px 20px;
+  background: rgba(13, 17, 23, 0.96);
+  border-bottom: 1px solid #2f6f73;
+  backdrop-filter: blur(6px);
+}
+
+.main-nav a {
+  color: #d0d7da;
+  text-decoration: none;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 6px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 4px;
+}
+
+.main-nav a:hover {
+  color: #ffffff;
+  border-color: #6fc3c8;
+}
+
+.main-nav a.active {
+  color: #a6ce39;
+  border-color: #a6ce39;
+  background: rgba(166, 206, 57, 0.12);
+}


### PR DESCRIPTION
### Motivation
- Centralize the repeated top navigation markup into a single component to simplify maintenance and ensure a consistent header across pages.
- Move per-page nav logic to a small client-side loader so pages can declare their active section with `data-page` rather than duplicating HTML.
- Provide an in-browser EA diagram workspace to accelerate diagram creation and conversion from PNGs and Claude slide context.
- Add a secure, local settings surface to manage API keys, MCP servers, model memory, and skills with encrypted storage.

### Description
- Added a reusable nav component at `components/nav.html` and updated multiple pages to inject it via `document.getElementById('nav-container')` and to set the active link using the page `data-page` attribute.
- Updated many HTML files to reference the consolidated `styles.css` and added `.main-nav` styles to `styles.css` to support the injected navigation UI.
- Introduced `excalidraw-ea.html`, an interactive Diagram Lab that embeds Excalidraw, supports PNG reference import, OCR via Tesseract.js, rectangle detection, and automatic creation of editable EA blocks and starter scenes (including Claude-triggered starter context).
- Replaced/truncated `settings.html` with a full-featured settings page implementing `SecureStorage` (AES-GCM wrappers), UI and CRUD operations for API keys, MCP servers, model memories, and skills, plus import/export and clear functionality.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8af35e5f48322b023ce0376a2411d)