### PR TITLE
Phase 1: Refactor drawing module to modular architecture (C4)

### DIFF
--- a/excalidraw-ea.html
+++ b/excalidraw-ea.html
@@ -378,8 +378,12 @@ fetch('components/nav.html')
         return;
       }
       console.warn('Modular renderer not available:', err);
-      // Fallback to inline
+      // Fallback to inline - sync UI with state
       currentRenderer = 'inline';
+      const toggle = document.getElementById('renderer-toggle');
+      if (toggle) {
+        toggle.value = 'inline';
+      }
       renderWithInlineRenderer(canvas, gen);
       updateRendererStatus('Modular renderer failed, using inline');
     });

--- a/excalidraw-ea.html
+++ b/excalidraw-ea.html
@@ -122,6 +122,7 @@ fetch('components/nav.html')
   let currentData = null;
   let schema = null;
   let currentRenderer = 'inline'; // 'inline' or 'modular'
+  let renderGeneration = 0; // Guard against stale async callbacks
 
   // Schema-to-Excalidraw converter (embedded to avoid module issues)
   function schemaToExcalidraw(schema) {
@@ -331,14 +332,18 @@ fetch('components/nav.html')
     container.innerHTML = '';
     container.appendChild(canvas);
 
+    // Increment generation to guard against stale async callbacks
+    renderGeneration++;
+    const currentGen = renderGeneration;
+
     if (currentRenderer === 'modular') {
-      renderWithModularRenderer(canvas);
+      renderWithModularRenderer(canvas, currentGen);
     } else {
-      renderWithInlineRenderer(canvas);
+      renderWithInlineRenderer(canvas, currentGen);
     }
   }
 
-  function renderWithInlineRenderer(canvas) {
+  function renderWithInlineRenderer(canvas, gen) {
     const ctx = canvas.getContext('2d');
     ctx.fillStyle = schema.canvas.background;
     ctx.fillRect(0, 0, canvas.width, canvas.height);
@@ -357,17 +362,25 @@ fetch('components/nav.html')
     updateRendererStatus('Inline renderer (monolithic)');
   }
 
-  function renderWithModularRenderer(canvas) {
+  function renderWithModularRenderer(canvas, gen) {
     // Dynamically import modular renderer
     import('./js/renderers/canvas-renderer.js').then(({ CanvasRenderer }) => {
+      // Guard against stale callback: only render if this is still the current generation
+      if (gen !== renderGeneration || currentRenderer !== 'modular') {
+        return;
+      }
       const renderer = new CanvasRenderer(canvas, schema);
       renderer.render(currentData.elements);
       updateRendererStatus('Modular renderer (C4 Phase 1)');
     }).catch(err => {
+      // Guard against stale callback
+      if (gen !== renderGeneration) {
+        return;
+      }
       console.warn('Modular renderer not available:', err);
       // Fallback to inline
       currentRenderer = 'inline';
-      renderWithInlineRenderer(canvas);
+      renderWithInlineRenderer(canvas, gen);
       updateRendererStatus('Modular renderer failed, using inline');
     });
   }

--- a/excalidraw-ea.html
+++ b/excalidraw-ea.html
@@ -95,6 +95,14 @@ fetch('components/nav.html')
   </div>
 
   <div class="diagram-controls">
+    <div style="display: flex; align-items: center; gap: 12px; flex: 1;">
+      <label for="renderer-toggle" style="font-weight: 600; margin: 0;">Renderer:</label>
+      <select id="renderer-toggle" style="padding: 8px 12px; border: 1px solid #ccc; border-radius: 4px; font-size: 14px; cursor: pointer;">
+        <option value="inline">Inline (Current)</option>
+        <option value="modular">Modular (C4 Phase 1)</option>
+      </select>
+      <span id="renderer-status" style="font-size: 12px; color: #666;"></span>
+    </div>
     <button id="download-btn">📥 Download JSON</button>
     <button id="export-png-btn">🖼️ Export as PNG</button>
     <button id="reset-btn">↻ Reset to Original</button>
@@ -113,6 +121,7 @@ fetch('components/nav.html')
   let originalData = null;
   let currentData = null;
   let schema = null;
+  let currentRenderer = 'inline'; // 'inline' or 'modular'
 
   // Schema-to-Excalidraw converter (embedded to avoid module issues)
   function schemaToExcalidraw(schema) {
@@ -319,11 +328,22 @@ fetch('components/nav.html')
     canvas.style.border = '1px solid #ddd';
     canvas.style.borderRadius = '4px';
 
+    container.innerHTML = '';
+    container.appendChild(canvas);
+
+    if (currentRenderer === 'modular') {
+      renderWithModularRenderer(canvas);
+    } else {
+      renderWithInlineRenderer(canvas);
+    }
+  }
+
+  function renderWithInlineRenderer(canvas) {
     const ctx = canvas.getContext('2d');
     ctx.fillStyle = schema.canvas.background;
     ctx.fillRect(0, 0, canvas.width, canvas.height);
 
-    // Draw all elements
+    // Draw all elements using inline functions
     currentData.elements.forEach(elem => {
       if (elem.type === 'rectangle') {
         drawRectangle(ctx, elem);
@@ -334,8 +354,29 @@ fetch('components/nav.html')
       }
     });
 
-    container.innerHTML = '';
-    container.appendChild(canvas);
+    updateRendererStatus('Inline renderer (monolithic)');
+  }
+
+  function renderWithModularRenderer(canvas) {
+    // Dynamically import modular renderer
+    import('./js/renderers/canvas-renderer.js').then(({ CanvasRenderer }) => {
+      const renderer = new CanvasRenderer(canvas, schema);
+      renderer.render(currentData.elements);
+      updateRendererStatus('Modular renderer (C4 Phase 1)');
+    }).catch(err => {
+      console.warn('Modular renderer not available:', err);
+      // Fallback to inline
+      currentRenderer = 'inline';
+      renderWithInlineRenderer(canvas);
+      updateRendererStatus('Modular renderer failed, using inline');
+    });
+  }
+
+  function updateRendererStatus(text) {
+    const statusEl = document.getElementById('renderer-status');
+    if (statusEl) {
+      statusEl.textContent = text;
+    }
   }
 
   function drawRectangle(ctx, elem) {
@@ -498,6 +539,15 @@ fetch('components/nav.html')
         renderDiagram();
       }
     };
+
+    // Renderer toggle
+    const rendererToggle = document.getElementById('renderer-toggle');
+    if (rendererToggle) {
+      rendererToggle.onchange = (e) => {
+        currentRenderer = e.target.value;
+        renderDiagram();
+      };
+    }
   }
 
   initDiagram();

--- a/js/renderers/canvas-renderer.js
+++ b/js/renderers/canvas-renderer.js
@@ -1,0 +1,46 @@
+import { ShapeRenderer } from './shape-renderer.js';
+
+/**
+ * CanvasRenderer
+ * High-level rendering orchestrator
+ * Handles canvas setup, element batching, and drawing pipeline
+ */
+export class CanvasRenderer {
+  constructor(canvas, schema) {
+    this.canvas = canvas;
+    this.schema = schema;
+    this.ctx = canvas.getContext('2d');
+    this.shapeRenderer = new ShapeRenderer(this.ctx);
+  }
+
+  /**
+   * Render complete diagram
+   */
+  render(elements) {
+    // Setup canvas
+    this._setupCanvas();
+
+    // Draw elements in order
+    elements.forEach(elem => {
+      if (elem.type === 'rectangle') {
+        this.shapeRenderer.drawRectangle(elem);
+      } else if (elem.type === 'text') {
+        this.shapeRenderer.drawText(elem);
+      } else if (elem.type === 'arrow') {
+        this.shapeRenderer.drawArrow(elem);
+      }
+    });
+  }
+
+  /**
+   * Private: Setup canvas size and background
+   */
+  _setupCanvas() {
+    this.canvas.width = this.schema.canvas.width;
+    this.canvas.height = this.schema.canvas.height;
+
+    // Fill background
+    this.ctx.fillStyle = this.schema.canvas.background;
+    this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
+  }
+}

--- a/js/renderers/shape-renderer.js
+++ b/js/renderers/shape-renderer.js
@@ -1,0 +1,154 @@
+/**
+ * ShapeRenderer
+ * Handles low-level canvas drawing primitives (rectangles, text, arrows)
+ * Decoupled from schema processing and high-level logic
+ */
+export class ShapeRenderer {
+  constructor(ctx) {
+    this.ctx = ctx;
+  }
+
+  /**
+   * Draw a rectangle with optional dashed stroke
+   */
+  drawRectangle(elem) {
+    const { x, y, width, height, backgroundColor, strokeColor, strokeWidth, strokeStyle, text, fontSize, color } = elem;
+
+    this.ctx.fillStyle = backgroundColor || '#ffffff';
+    this.ctx.strokeStyle = strokeColor || '#000000';
+    this.ctx.lineWidth = strokeWidth || 2;
+    this.ctx.fillRect(x, y, width, height);
+
+    // Apply dashed stroke style if specified
+    if (strokeStyle === 'dashed') {
+      this.ctx.setLineDash([5, 5]);
+    }
+    this.ctx.strokeRect(x, y, width, height);
+    this.ctx.setLineDash([]);
+
+    // Render text if present
+    if (text) {
+      this._drawTextInRect(x, y, width, height, text, fontSize, color);
+    }
+  }
+
+  /**
+   * Draw text (standalone)
+   */
+  drawText(elem) {
+    const { x, y, text, fontSize, color } = elem;
+    if (!text) return;
+
+    this.ctx.fillStyle = color || '#000000';
+    this.ctx.font = `${fontSize || 12}px Arial`;
+    this.ctx.textAlign = 'left';
+    this.ctx.textBaseline = 'top';
+    this.ctx.fillText(text, x, y);
+  }
+
+  /**
+   * Draw arrow with optional label
+   */
+  drawArrow(elem) {
+    const { x, y, width, height, strokeColor, strokeWidth, strokeStyle, text, fontSize } = elem;
+    const toX = x + width;
+    const toY = y + height;
+
+    // Draw line
+    this.ctx.strokeStyle = strokeColor || '#000000';
+    this.ctx.lineWidth = strokeWidth || 2;
+
+    if (strokeStyle === 'dotted') {
+      this.ctx.setLineDash([5, 5]);
+    }
+
+    this.ctx.beginPath();
+    this.ctx.moveTo(x, y);
+    this.ctx.lineTo(toX, toY);
+    this.ctx.stroke();
+    this.ctx.setLineDash([]);
+
+    // Draw arrowhead
+    this._drawArrowHead(x, y, toX, toY, strokeColor);
+
+    // Render label if present
+    if (text) {
+      this._drawArrowLabel(x, y, toX, toY, text, fontSize, strokeColor);
+    }
+  }
+
+  /**
+   * Private: Draw arrowhead triangle
+   */
+  _drawArrowHead(fromX, fromY, toX, toY, color) {
+    const headlen = 15;
+    const angle = Math.atan2(toY - fromY, toX - fromX);
+
+    this.ctx.fillStyle = color || '#000000';
+    this.ctx.beginPath();
+    this.ctx.moveTo(toX, toY);
+    this.ctx.lineTo(toX - headlen * Math.cos(angle - Math.PI / 6), toY - headlen * Math.sin(angle - Math.PI / 6));
+    this.ctx.lineTo(toX - headlen * Math.cos(angle + Math.PI / 6), toY - headlen * Math.sin(angle + Math.PI / 6));
+    this.ctx.closePath();
+    this.ctx.fill();
+  }
+
+  /**
+   * Private: Draw label text on arrow, offset perpendicular
+   */
+  _drawArrowLabel(fromX, fromY, toX, toY, text, fontSize, color) {
+    const midX = (fromX + toX) / 2;
+    const midY = (fromY + toY) / 2;
+
+    this.ctx.fillStyle = color || '#000000';
+    this.ctx.font = `${fontSize || 11}px Arial`;
+    this.ctx.textAlign = 'center';
+    this.ctx.textBaseline = 'bottom';
+
+    // Offset label perpendicular to the line
+    const lineAngle = Math.atan2(toY - fromY, toX - fromX);
+    const perpAngle = lineAngle + Math.PI / 2;
+    const offsetDist = 10;
+
+    const labelX = midX + offsetDist * Math.cos(perpAngle);
+    const labelY = midY + offsetDist * Math.sin(perpAngle);
+
+    this.ctx.fillText(text, labelX, labelY);
+  }
+
+  /**
+   * Private: Draw wrapped text inside rectangle bounds
+   */
+  _drawTextInRect(x, y, width, height, text, fontSize, color) {
+    this.ctx.fillStyle = color || '#000000';
+    this.ctx.font = `${fontSize || 14}px Arial`;
+    this.ctx.textAlign = 'center';
+    this.ctx.textBaseline = 'middle';
+
+    const maxWidth = width - 10;
+    const words = text.split(' ');
+    let lines = [];
+    let line = '';
+
+    words.forEach(word => {
+      const testLine = line ? line + ' ' + word : word;
+      const metrics = this.ctx.measureText(testLine);
+      if (metrics.width > maxWidth && line) {
+        lines.push(line);
+        line = word;
+      } else {
+        line = testLine;
+      }
+    });
+    if (line) lines.push(line);
+
+    const lineHeight = fontSize || 14;
+    const totalHeight = lines.length * lineHeight;
+    let textY = y + height / 2 - totalHeight / 2 + lineHeight / 2;
+
+    lines.forEach(l => {
+      this.ctx.fillText(l, x + width / 2, textY);
+      textY += lineHeight;
+    });
+  }
+}


### PR DESCRIPTION
## Phase 1 Refactoring: Modular Renderer Architecture (C4)

Extracts low-level canvas drawing into separate modules to support multi-renderer architecture. Both renderers produce identical output; this is a **safe refactoring** that enables future architectural improvements.

## Changes

### New Modules

**js/renderers/shape-renderer.js** — `ShapeRenderer` class
- Low-level canvas primitives: rectangle, text, arrow
- Encapsulates all drawing logic
- Dashed stroke support (`ctx.setLineDash`)
- Arrow labels with perpendicular positioning
- Text wrapping in constrained bounds

**js/renderers/canvas-renderer.js** — `CanvasRenderer` class  
- High-level rendering orchestrator
- Canvas setup and element batching
- Delegates to ShapeRenderer for primitives
- Dependency injection pattern (canvas + schema)

### Updated Files

**excalidraw-ea.html**
- Add renderer toggle dropdown: "Inline (Current)" vs "Modular (C4 Phase 1)"
- `renderDiagram()` dispatches to selected renderer
- `renderWithModularRenderer()` — uses new CanvasRenderer class
- `renderWithInlineRenderer()` — uses original inline functions
- Graceful fallback if modular renderer fails
- Status message shows active renderer

## Architecture Improvements

| Aspect | Before | After |
|--------|--------|-------|
| Organization | Monolithic | Modular |
| Testability | Difficult | Testable classes |
| Reusability | Tied to HTML | Importable modules |
| Extensibility | Complex | Add new Renderer class |
| Dependencies | Hidden | Explicit imports |

## How to Compare

1. Open `/excalidraw-ea.html`
2. Use "Renderer" dropdown to switch
3. Both produce identical visual output
4. Monitor console and "Renderer" status line

## Next Steps (Phase 2-4)

- **Phase 2:** Extract schema processing into class
- **Phase 3:** Extract UI controller
- **Phase 4:** Add style engine, support C4 diagrams

## Status

✅ Both renderers identical
✅ Modular code ready for inheritance/extension
✅ No breaking changes

https://claude.ai/code/session_01FvTo9MstEMdvX2Afmq8Vpb

---
_Generated by [Claude Code](https://claude.ai/code/session_01FvTo9MstEMdvX2Afmq8Vpb)_